### PR TITLE
Fix unreliable packet failures

### DIFF
--- a/FizzySteamworks.cs
+++ b/FizzySteamworks.cs
@@ -2,6 +2,7 @@ using Steamworks;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using UnityEngine;
 
 namespace Mirror.FizzySteam
@@ -96,7 +97,7 @@ namespace Mirror.FizzySteam
             ClientConnect(uri.Host);
         }
 
-        public override bool ClientSend(int channelId, ArraySegment<byte> segment) => client.Send(segment.Array, channelId);
+        public override bool ClientSend(int channelId, ArraySegment<byte> segment) => client.Send(segment.ToArray(), channelId);
         public override void ClientDisconnect()
         {
             if (ClientActive())
@@ -148,7 +149,7 @@ namespace Mirror.FizzySteam
             return steamBuilder.Uri;
         }
 
-        public override bool ServerSend(List<int> connectionIds, int channelId, ArraySegment<byte> segment) => ServerActive() && server.SendAll(connectionIds, segment.Array, channelId);
+        public override bool ServerSend(List<int> connectionIds, int channelId, ArraySegment<byte> segment) => ServerActive() && server.SendAll(connectionIds, segment.ToArray(), channelId);
         public override bool ServerDisconnect(int connectionId) => ServerActive() && server.Disconnect(connectionId);
         public override string ServerGetClientAddress(int connectionId) => ServerActive() ? server.ServerGetClientAddress(connectionId) : string.Empty;
         public override void ServerStop()


### PR DESCRIPTION
segment.Array was returning the entire underlying array instead of just the subset that was relevant to the send. Change this to segment.ToArray() resolved the issue.