### PR TITLE
Wrapped steamworks code in !DISABLESTEAMWORKS

### DIFF
--- a/FizzySteamworks.cs
+++ b/FizzySteamworks.cs
@@ -1,3 +1,4 @@
+#if !DISABLESTEAMWORKS
 using Steamworks;
 using System;
 using System.IO;
@@ -299,3 +300,4 @@ namespace Mirror.FizzySteam
     }
   }
 }
+#endif // !DISABLESTEAMWORKS

--- a/LegacyClient.cs
+++ b/LegacyClient.cs
@@ -1,4 +1,5 @@
-﻿using Steamworks;
+﻿#if !DISABLESTEAMWORKS
+using Steamworks;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -167,3 +168,4 @@ namespace Mirror.FizzySteam
     public void FlushData() { }
   }
 }
+#endif // !DISABLESTEAMWORKS

--- a/LegacyCommon.cs
+++ b/LegacyCommon.cs
@@ -1,4 +1,5 @@
-﻿using Steamworks;
+﻿#if !DISABLESTEAMWORKS
+using Steamworks;
 using System;
 using System.Collections;
 using UnityEngine;
@@ -147,3 +148,4 @@ namespace Mirror.FizzySteam
     protected abstract void OnConnectionFailed(CSteamID remoteId);
   }
 }
+#endif // !DISABLESTEAMWORKS

--- a/LegacyServer.cs
+++ b/LegacyServer.cs
@@ -1,4 +1,5 @@
-﻿using Steamworks;
+﻿#if !DISABLESTEAMWORKS
+using Steamworks;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -151,3 +152,4 @@ namespace Mirror.FizzySteam
     public void FlushData() { }
   }
 }
+#endif // !DISABLESTEAMWORKS

--- a/NextClient.cs
+++ b/NextClient.cs
@@ -1,3 +1,4 @@
+#if !DISABLESTEAMWORKS
 using Steamworks;
 using System;
 using System.Collections.Generic;
@@ -217,3 +218,4 @@ namespace Mirror.FizzySteam
     }
   }
 }
+#endif // !DISABLESTEAMWORKS

--- a/NextCommon.cs
+++ b/NextCommon.cs
@@ -1,3 +1,4 @@
+#if !DISABLESTEAMWORKS
 using Mirror;
 using Steamworks;
 using System;
@@ -39,3 +40,4 @@ public abstract class NextCommon
     return (managedArray, channel);
   }
 }
+#endif // !DISABLESTEAMWORKS

--- a/NextServer.cs
+++ b/NextServer.cs
@@ -1,3 +1,4 @@
+#if !DISABLESTEAMWORKS
 using Steamworks;
 using System;
 using System.Linq;
@@ -203,3 +204,4 @@ namespace Mirror.FizzySteam
     }
   }
 }
+#endif // !DISABLESTEAMWORKS


### PR DESCRIPTION
So that it's possible to have multiple transports in the project without having to have steamworks enabled. In my project I decide transport at runtime, KCP in the editor and FizzySteamworks in steam builds. This doesn't affect those who have steam-only projects.