### PR TITLE
Corrected multiple bugs, removed dependency on SteamManager, enabled …

### DIFF
--- a/BidirectionalDictionary.cs
+++ b/BidirectionalDictionary.cs
@@ -3,87 +3,87 @@ using System.Collections.Generic;
 
 namespace Mirror.FizzySteam
 {
-  public class BidirectionalDictionary<T1, T2> : IEnumerable
-  {
-    private Dictionary<T1, T2> t1ToT2Dict = new Dictionary<T1, T2>();
-    private Dictionary<T2, T1> t2ToT1Dict = new Dictionary<T2, T1>();
-
-    public IEnumerable<T1> FirstTypes => t1ToT2Dict.Keys;
-    public IEnumerable<T2> SecondTypes => t2ToT1Dict.Keys;
-
-    public IEnumerator GetEnumerator() => t1ToT2Dict.GetEnumerator();
-
-    public int Count => t1ToT2Dict.Count;
-
-    public void Add(T1 key, T2 value)
+    public class BidirectionalDictionary<T1, T2> : IEnumerable
     {
-      if(t1ToT2Dict.ContainsKey(key))
-      {
-        Remove(key);
-      }
+        private Dictionary<T1, T2> t1ToT2Dict = new Dictionary<T1, T2>();
+        private Dictionary<T2, T1> t2ToT1Dict = new Dictionary<T2, T1>();
 
-      t1ToT2Dict[key] = value;
-      t2ToT1Dict[value] = key;
+        public IEnumerable<T1> FirstTypes => t1ToT2Dict.Keys;
+        public IEnumerable<T2> SecondTypes => t2ToT1Dict.Keys;
+
+        public IEnumerator GetEnumerator() => t1ToT2Dict.GetEnumerator();
+
+        public int Count => t1ToT2Dict.Count;
+
+        public void Add(T1 key, T2 value)
+        {
+            if (t1ToT2Dict.ContainsKey(key))
+            {
+                Remove(key);
+            }
+
+            t1ToT2Dict[key] = value;
+            t2ToT1Dict[value] = key;
+        }
+
+        public void Add(T2 key, T1 value)
+        {
+            if (t2ToT1Dict.ContainsKey(key))
+            {
+                Remove(key);
+            }
+
+            t2ToT1Dict[key] = value;
+            t1ToT2Dict[value] = key;
+        }
+
+        public T2 Get(T1 key) => t1ToT2Dict[key];
+
+        public T1 Get(T2 key) => t2ToT1Dict[key];
+
+        public bool TryGetValue(T1 key, out T2 value) => t1ToT2Dict.TryGetValue(key, out value);
+
+        public bool TryGetValue(T2 key, out T1 value) => t2ToT1Dict.TryGetValue(key, out value);
+
+        public bool Contains(T1 key) => t1ToT2Dict.ContainsKey(key);
+
+        public bool Contains(T2 key) => t2ToT1Dict.ContainsKey(key);
+
+        public void Remove(T1 key)
+        {
+            if (Contains(key))
+            {
+                T2 val = t1ToT2Dict[key];
+                t1ToT2Dict.Remove(key);
+                t2ToT1Dict.Remove(val);
+            }
+        }
+        public void Remove(T2 key)
+        {
+            if (Contains(key))
+            {
+                T1 val = t2ToT1Dict[key];
+                t1ToT2Dict.Remove(val);
+                t2ToT1Dict.Remove(key);
+            }
+        }
+
+        public T1 this[T2 key]
+        {
+            get => t2ToT1Dict[key];
+            set
+            {
+                Add(key, value);
+            }
+        }
+
+        public T2 this[T1 key]
+        {
+            get => t1ToT2Dict[key];
+            set
+            {
+                Add(key, value);
+            }
+        }
     }
-
-    public void Add(T2 key, T1 value)
-    {
-      if (t2ToT1Dict.ContainsKey(key))
-      {
-        Remove(key);
-      }
-
-      t2ToT1Dict[key] = value;
-      t1ToT2Dict[value] = key;
-    }
-
-    public T2 Get(T1 key) => t1ToT2Dict[key];
-
-    public T1 Get(T2 key) => t2ToT1Dict[key];
-
-    public bool TryGetValue(T1 key, out T2 value) => t1ToT2Dict.TryGetValue(key, out value);
-
-    public bool TryGetValue(T2 key, out T1 value) => t2ToT1Dict.TryGetValue(key, out value);
-
-    public bool Contains(T1 key) => t1ToT2Dict.ContainsKey(key);
-
-    public bool Contains(T2 key) => t2ToT1Dict.ContainsKey(key);
-
-    public void Remove(T1 key)
-    {
-      if (Contains(key))
-      {
-        T2 val = t1ToT2Dict[key];
-        t1ToT2Dict.Remove(key);
-        t2ToT1Dict.Remove(val);
-      }
-    }
-    public void Remove(T2 key)
-    {
-      if (Contains(key))
-      {
-        T1 val = t2ToT1Dict[key];
-        t1ToT2Dict.Remove(val);
-        t2ToT1Dict.Remove(key);
-      }
-    }
-
-    public T1 this[T2 key]
-    {
-      get => t2ToT1Dict[key];
-      set
-      {
-        Add(key, value);
-      }
-    }
-
-    public T2 this[T1 key]
-    {
-      get => t1ToT2Dict[key];
-      set
-      {
-        Add(key, value);
-      }
-    }
-  }
 }

--- a/FizzySteamworks.cs
+++ b/FizzySteamworks.cs
@@ -6,298 +6,302 @@ using UnityEngine;
 
 namespace Mirror.FizzySteam
 {
-  [HelpURL("https://github.com/Chykary/FizzySteamworks")]
-  public class FizzySteamworks : Transport
-  {
-    private const string STEAM_SCHEME = "steam";
-
-    private static IClient client;
-    private static IServer server;
-
-    [SerializeField]
-    public EP2PSend[] Channels = new EP2PSend[2] { EP2PSend.k_EP2PSendReliable, EP2PSend.k_EP2PSendUnreliableNoDelay };
-
-    [Tooltip("Timeout for connecting in seconds.")]
-    public int Timeout = 25;
-    [Tooltip("The Steam ID for your application.")]
-    public string SteamAppID = "480";
-    [Tooltip("Allow or disallow P2P connections to fall back to being relayed through the Steam servers if a direct connection or NAT-traversal cannot be established.")]
-    public bool AllowSteamRelay = true;
-
-    [Tooltip("Use SteamSockets instead of the (deprecated) SteamNetworking. This will always use Relay.")]
-    public bool UseNextGenSteamNetworking = true;
-
-    [Header("Info")]
-    [Tooltip("This will display your Steam User ID when you start or connect to a server.")]
-    public ulong SteamUserID;
-
-    private void Awake()
+    [HelpURL("https://github.com/Chykary/FizzySteamworks")]
+    public class FizzySteamworks : Transport
     {
-      const string fileName = "steam_appid.txt";
-      if (File.Exists(fileName))
-      {
-        string content = File.ReadAllText(fileName);
-        if (content != SteamAppID)
+        private const string STEAM_SCHEME = "steam";
+
+        private static IClient client;
+        private static IServer server;
+
+        [SerializeField]
+        public EP2PSend[] Channels = new EP2PSend[2] { EP2PSend.k_EP2PSendReliable, EP2PSend.k_EP2PSendUnreliableNoDelay };
+
+        [Tooltip("Timeout for connecting in seconds.")]
+        public int Timeout = 25;
+        [Tooltip("Allow or disallow P2P connections to fall back to being relayed through the Steam servers if a direct connection or NAT-traversal cannot be established.")]
+        public bool AllowSteamRelay = true;
+
+        [Tooltip("Use SteamSockets instead of the (deprecated) SteamNetworking. This will always use Relay.")]
+        public bool UseNextGenSteamNetworking = true;
+
+        private void OnEnable()
         {
-          File.WriteAllText(fileName, SteamAppID.ToString());
-          Debug.Log($"Updating {fileName}. Previous: {content}, new SteamAppID {SteamAppID}");
-        }
-      }
-      else
-      {
-        File.WriteAllText(fileName, SteamAppID.ToString());
-        Debug.Log($"New {fileName} written with SteamAppID {SteamAppID}");
-      }
-    }
-
-    private void OnEnable()
-    {
-      Debug.Assert(Channels != null && Channels.Length > 0, "No channel configured for FizzySteamworks.");
-      Invoke(nameof(FetchSteamID), 1f);
-    }
-
-    public override void ClientEarlyUpdate()
-    {
-      if(enabled)
-      {
-        client?.ReceiveData();
-      }
-    }
-
-    public override void ServerEarlyUpdate()
-    {
-      if(enabled)
-      {
-        server?.ReceiveData();
-      }
-    }
-
-    public override void ClientLateUpdate()
-    {
-      if (enabled)
-      {
-        client?.FlushData();
-      }
-    }
-
-    public override void ServerLateUpdate()
-    {
-      if (enabled)
-      {
-        server?.FlushData();
-      }
-    }
-
-    public override bool ClientConnected() => ClientActive() && client.Connected;
-    public override void ClientConnect(string address)
-    {
-      if (!SteamManager.Initialized)
-      {
-        Debug.LogError("SteamWorks not initialized. Client could not be started.");
-        OnClientDisconnected.Invoke();
-        return;
-      }
-
-      FetchSteamID();
-
-      if (ServerActive())
-      {
-        Debug.LogError("Transport already running as server!");
-        return;
-      }
-
-      if (!ClientActive() || client.Error)
-      {
-        if (UseNextGenSteamNetworking)
-        {
-          Debug.Log($"Starting client [SteamSockets], target address {address}.");
-          client = NextClient.CreateClient(this, address);
-        }
-        else
-        {
-          Debug.Log($"Starting client [DEPRECATED SteamNetworking], target address {address}. Relay enabled: {AllowSteamRelay}");
-          SteamNetworking.AllowP2PPacketRelay(AllowSteamRelay);
-          client = LegacyClient.CreateClient(this, address);
-        }
-      }
-      else
-      {
-        Debug.LogError("Client already running!");
-      }
-    }
-
-    public override void ClientConnect(Uri uri)
-    {
-      if (uri.Scheme != STEAM_SCHEME)
-        throw new ArgumentException($"Invalid url {uri}, use {STEAM_SCHEME}://SteamID instead", nameof(uri));
-
-      ClientConnect(uri.Host);
-    }
-
-    public override void ClientSend(ArraySegment<byte> segment, int channelId)
-    {
-      byte[] data = new byte[segment.Count];
-      Array.Copy(segment.Array, segment.Offset, data, 0, segment.Count);
-      client.Send(data, channelId);
-    }
-
-    public override void ClientDisconnect()
-    {
-      if (ClientActive())
-      {
-        Shutdown();
-      }
-    }
-    public bool ClientActive() => client != null;
-
-
-    public override bool ServerActive() => server != null;
-    public override void ServerStart()
-    {
-      if (!SteamManager.Initialized)
-      {
-        Debug.LogError("SteamWorks not initialized. Server could not be started.");
-        return;
-      }
-
-      FetchSteamID();
-
-      if (ClientActive())
-      {
-        Debug.LogError("Transport already running as client!");
-        return;
-      }
-
-      if (!ServerActive())
-      {
-        if (UseNextGenSteamNetworking)
-        {
-          Debug.Log($"Starting server [SteamSockets].");
-          server = NextServer.CreateServer(this, NetworkManager.singleton.maxConnections);
-        }
-        else
-        {
-          Debug.Log($"Starting server [DEPRECATED SteamNetworking]. Relay enabled: {AllowSteamRelay}");
-          SteamNetworking.AllowP2PPacketRelay(AllowSteamRelay);
-          server = LegacyServer.CreateServer(this, NetworkManager.singleton.maxConnections);
-        }
-      }
-      else
-      {
-        Debug.LogError("Server already started!");
-      }
-    }
-
-    public override Uri ServerUri()
-    {
-      var steamBuilder = new UriBuilder
-      {
-        Scheme = STEAM_SCHEME,
-        Host = SteamUser.GetSteamID().m_SteamID.ToString()
-      };
-
-      return steamBuilder.Uri;
-    }
-
-    public override void ServerSend(int connectionId, ArraySegment<byte> segment, int channelId)
-    {
-      if (ServerActive())
-      {
-        byte[] data = new byte[segment.Count];
-        Array.Copy(segment.Array, segment.Offset, data, 0, segment.Count);
-        server.Send(connectionId, data, channelId);
-      }
-    }
-    public override void ServerDisconnect(int connectionId)
-    {
-      if (ServerActive())
-      {
-        server.Disconnect(connectionId);
-      }
-    }
-    public override string ServerGetClientAddress(int connectionId) => ServerActive() ? server.ServerGetClientAddress(connectionId) : string.Empty;
-    public override void ServerStop()
-    {
-      if (ServerActive())
-      {
-        Shutdown();
-      }
-    }
-
-    public override void Shutdown()
-    {
-      if (server != null)
-      {
-        server.Shutdown();
-        server = null;
-        Debug.Log("Transport shut down - was server.");
-      }
-
-      if (client != null)
-      {
-        client.Disconnect();
-        client = null;
-        Debug.Log("Transport shut down - was client.");
-      }
-    }
-
-    public override int GetMaxPacketSize(int channelId)
-    {
-      if (UseNextGenSteamNetworking)
-      {
-        return Constants.k_cbMaxSteamNetworkingSocketsMessageSizeSend;
-      }
-      else
-      {
-        if (channelId >= Channels.Length)
-        {
-          Debug.LogError("Channel Id exceeded configured channels! Please configure more channels.");
-          return 1200;
+            Debug.Assert(Channels != null && Channels.Length > 0, "No channel configured for FizzySteamworks.");
+            Invoke(nameof(InitRelayNetworkAccess), 1f);
         }
 
-        switch (Channels[channelId])
+        public override void ClientEarlyUpdate()
         {
-          case EP2PSend.k_EP2PSendUnreliable:
-          case EP2PSend.k_EP2PSendUnreliableNoDelay:
-            return 1200;
-          case EP2PSend.k_EP2PSendReliable:
-          case EP2PSend.k_EP2PSendReliableWithBuffering:
-            return 1048576;
-          default:
-            throw new NotSupportedException();
-        }
-      }
-    }
-
-    public override bool Available()
-    {
-      try
-      {
-        return SteamManager.Initialized;
-      }
-      catch
-      {
-        return false;
-      }
-    }
-
-    private void FetchSteamID()
-    {
-      if (SteamManager.Initialized)
-      {
-        if (UseNextGenSteamNetworking)
-        {
-          SteamNetworkingUtils.InitRelayNetworkAccess();
+            if (enabled)
+            {
+                client?.ReceiveData();
+            }
         }
 
-        SteamUserID = SteamUser.GetSteamID().m_SteamID;
-      }
-    }
+        public override void ServerEarlyUpdate()
+        {
+            if (enabled)
+            {
+                server?.ReceiveData();
+            }
+        }
 
-    private void OnDestroy()
-    {
-      Shutdown();
+        public override void ClientLateUpdate()
+        {
+            if (enabled)
+            {
+                client?.FlushData();
+            }
+        }
+
+        public override void ServerLateUpdate()
+        {
+            if (enabled)
+            {
+                server?.FlushData();
+            }
+        }
+
+        public override bool ClientConnected() => ClientActive() && client.Connected;
+        public override void ClientConnect(string address)
+        {
+            try
+            {
+#if UNITY_SERVER
+                SteamGameServerNetworkingUtils.InitRelayNetworkAccess();
+#else
+                SteamNetworkingUtils.InitRelayNetworkAccess();
+#endif
+
+                InitRelayNetworkAccess();
+
+                if (ServerActive())
+                {
+                    Debug.LogError("Transport already running as server!");
+                    return;
+                }
+
+                if (!ClientActive() || client.Error)
+                {
+                    if (UseNextGenSteamNetworking)
+                    {
+                        Debug.Log($"Starting client [SteamSockets], target address {address}.");
+                        client = NextClient.CreateClient(this, address);
+                    }
+                    else
+                    {
+                        Debug.Log($"Starting client [DEPRECATED SteamNetworking], target address {address}. Relay enabled: {AllowSteamRelay}");
+                        SteamNetworking.AllowP2PPacketRelay(AllowSteamRelay);
+                        client = LegacyClient.CreateClient(this, address);
+                    }
+                }
+                else
+                {
+                    Debug.LogError("Client already running!");
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError("Exception: " + ex.Message + ". Client could not be started.");
+                OnClientDisconnected.Invoke();
+            }
+        }
+
+        public override void ClientConnect(Uri uri)
+        {
+            if (uri.Scheme != STEAM_SCHEME)
+                throw new ArgumentException($"Invalid url {uri}, use {STEAM_SCHEME}://SteamID instead", nameof(uri));
+
+            ClientConnect(uri.Host);
+        }
+
+        public override void ClientSend(ArraySegment<byte> segment, int channelId)
+        {
+            byte[] data = new byte[segment.Count];
+            Array.Copy(segment.Array, segment.Offset, data, 0, segment.Count);
+            client.Send(data, channelId);
+        }
+
+        public override void ClientDisconnect()
+        {
+            if (ClientActive())
+            {
+                Shutdown();
+            }
+        }
+        public bool ClientActive() => client != null;
+
+
+        public override bool ServerActive() => server != null;
+        public override void ServerStart()
+        {
+            try
+            {
+#if UNITY_SERVER
+                SteamGameServerNetworkingUtils.InitRelayNetworkAccess();
+#else
+                SteamNetworkingUtils.InitRelayNetworkAccess();
+#endif
+
+
+                InitRelayNetworkAccess();
+
+                if (ClientActive())
+                {
+                    Debug.LogError("Transport already running as client!");
+                    return;
+                }
+
+                if (!ServerActive())
+                {
+                    if (UseNextGenSteamNetworking)
+                    {
+                        Debug.Log($"Starting server [SteamSockets].");
+                        server = NextServer.CreateServer(this, NetworkManager.singleton.maxConnections);
+                    }
+                    else
+                    {
+                        Debug.Log($"Starting server [DEPRECATED SteamNetworking]. Relay enabled: {AllowSteamRelay}");
+#if UNITY_SERVER
+                        SteamGameServerNetworking.AllowP2PPacketRelay(AllowSteamRelay);
+#else
+
+                        SteamNetworking.AllowP2PPacketRelay(AllowSteamRelay);
+#endif
+                        server = LegacyServer.CreateServer(this, NetworkManager.singleton.maxConnections);
+                    }
+                }
+                else
+                {
+                    Debug.LogError("Server already started!");
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogException(ex);
+                return;
+            }
+        }
+
+        public override Uri ServerUri()
+        {
+            var steamBuilder = new UriBuilder
+            {
+                Scheme = STEAM_SCHEME,
+                Host = SteamUser.GetSteamID().m_SteamID.ToString()
+            };
+
+            return steamBuilder.Uri;
+        }
+
+        public override void ServerSend(int connectionId, ArraySegment<byte> segment, int channelId)
+        {
+            if (ServerActive())
+            {
+                byte[] data = new byte[segment.Count];
+                Array.Copy(segment.Array, segment.Offset, data, 0, segment.Count);
+                server.Send(connectionId, data, channelId);
+            }
+        }
+        public override void ServerDisconnect(int connectionId)
+        {
+            if (ServerActive())
+            {
+                server.Disconnect(connectionId);
+            }
+        }
+        public override string ServerGetClientAddress(int connectionId) => ServerActive() ? server.ServerGetClientAddress(connectionId) : string.Empty;
+        public override void ServerStop()
+        {
+            if (ServerActive())
+            {
+                Shutdown();
+            }
+        }
+
+        public override void Shutdown()
+        {
+            if (server != null)
+            {
+                server.Shutdown();
+                server = null;
+                Debug.Log("Transport shut down - was server.");
+            }
+
+            if (client != null)
+            {
+                client.Disconnect();
+                client = null;
+                Debug.Log("Transport shut down - was client.");
+            }
+        }
+
+        public override int GetMaxPacketSize(int channelId)
+        {
+            if (UseNextGenSteamNetworking)
+            {
+                return Constants.k_cbMaxSteamNetworkingSocketsMessageSizeSend;
+            }
+            else
+            {
+                if (channelId >= Channels.Length)
+                {
+                    Debug.LogError("Channel Id exceeded configured channels! Please configure more channels.");
+                    return 1200;
+                }
+
+                switch (Channels[channelId])
+                {
+                    case EP2PSend.k_EP2PSendUnreliable:
+                    case EP2PSend.k_EP2PSendUnreliableNoDelay:
+                        return 1200;
+                    case EP2PSend.k_EP2PSendReliable:
+                    case EP2PSend.k_EP2PSendReliableWithBuffering:
+                        return 1048576;
+                    default:
+                        throw new NotSupportedException();
+                }
+            }
+        }
+
+        public override bool Available()
+        {
+            try
+            {
+#if UNITY_SERVER
+                SteamGameServerNetworkingUtils.InitRelayNetworkAccess();
+#else
+                SteamNetworkingUtils.InitRelayNetworkAccess();
+#endif
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private void InitRelayNetworkAccess()
+        {
+            try
+            {
+                if (UseNextGenSteamNetworking)
+                {
+#if UNITY_SERVER
+                    SteamGameServerNetworkingUtils.InitRelayNetworkAccess();
+#else
+                    SteamNetworkingUtils.InitRelayNetworkAccess();
+#endif
+                }
+            }
+            catch { }
+        }
+
+        private void OnDestroy()
+        {
+            Shutdown();
+        }
     }
-  }
 }
 #endif // !DISABLESTEAMWORKS

--- a/IClient.cs
+++ b/IClient.cs
@@ -1,14 +1,14 @@
 namespace Mirror.FizzySteam
 {
-  public interface IClient
-  {
-    bool Connected { get; }
-    bool Error { get; }
+    public interface IClient
+    {
+        bool Connected { get; }
+        bool Error { get; }
 
 
-    void ReceiveData();
-    void Disconnect();
-    void FlushData();
-    void Send(byte[] data, int channelId);
-  }
+        void ReceiveData();
+        void Disconnect();
+        void FlushData();
+        void Send(byte[] data, int channelId);
+    }
 }

--- a/IServer.cs
+++ b/IServer.cs
@@ -1,12 +1,12 @@
 namespace Mirror.FizzySteam
 {
-  public interface IServer
-  {
-    void ReceiveData();
-    void Send(int connectionId, byte[] data, int channelId);
-    void Disconnect(int connectionId);
-    void FlushData();
-    string ServerGetClientAddress(int connectionId);
-    void Shutdown();
-  }
+    public interface IServer
+    {
+        void ReceiveData();
+        void Send(int connectionId, byte[] data, int channelId);
+        void Disconnect(int connectionId);
+        void FlushData();
+        string ServerGetClientAddress(int connectionId);
+        void Shutdown();
+    }
 }

--- a/LegacyClient.cs
+++ b/LegacyClient.cs
@@ -7,165 +7,171 @@ using UnityEngine;
 
 namespace Mirror.FizzySteam
 {
-  public class LegacyClient : LegacyCommon, IClient
-  {
-    public bool Connected { get; private set; }
-    public bool Error { get; private set; }
-
-    private event Action<byte[], int> OnReceivedData;
-    private event Action OnConnected;
-    private event Action OnDisconnected;
-
-    private TimeSpan ConnectionTimeout;
-
-    private CSteamID hostSteamID = CSteamID.Nil;
-    private TaskCompletionSource<Task> connectedComplete;
-    private CancellationTokenSource cancelToken;
-
-    private LegacyClient(FizzySteamworks transport) : base(transport)
+    public class LegacyClient : LegacyCommon, IClient
     {
-      ConnectionTimeout = TimeSpan.FromSeconds(Math.Max(1, transport.Timeout));
-    }
+        public bool Connected { get; private set; }
+        public bool Error { get; private set; }
 
-    public static LegacyClient CreateClient(FizzySteamworks transport, string host)
-    {
-      LegacyClient c = new LegacyClient(transport);
+        private event Action<byte[], int> OnReceivedData;
+        private event Action OnConnected;
+        private event Action OnDisconnected;
 
-      c.OnConnected += () => transport.OnClientConnected.Invoke();
-      c.OnDisconnected += () => transport.OnClientDisconnected.Invoke();
-      c.OnReceivedData += (data, channel) => transport.OnClientDataReceived.Invoke(new ArraySegment<byte>(data), channel);
+        private TimeSpan ConnectionTimeout;
 
-      if (SteamManager.Initialized)
-      {
-        c.Connect(host);
-      }
-      else
-      {
-        Debug.LogError("SteamWorks not initialized");
-        c.OnConnectionFailed(CSteamID.Nil);
-      }
+        private CSteamID hostSteamID = CSteamID.Nil;
+        private TaskCompletionSource<Task> connectedComplete;
+        private CancellationTokenSource cancelToken;
 
-      return c;
-    }
-
-    private async void Connect(string host)
-    {
-      cancelToken = new CancellationTokenSource();
-
-      try
-      {
-        hostSteamID = new CSteamID(UInt64.Parse(host));
-        connectedComplete = new TaskCompletionSource<Task>();
-
-        OnConnected += SetConnectedComplete;
-
-        SendInternal(hostSteamID, InternalMessages.CONNECT);
-
-        Task connectedCompleteTask = connectedComplete.Task;
-        Task timeOutTask = Task.Delay(ConnectionTimeout, cancelToken.Token);
-
-        if (await Task.WhenAny(connectedCompleteTask, timeOutTask) != connectedCompleteTask)
+        private LegacyClient(FizzySteamworks transport) : base(transport)
         {
-          if (cancelToken.IsCancellationRequested)
-          {
-            Debug.LogError($"The connection attempt was cancelled.");
-          }
-          else if (timeOutTask.IsCompleted)
-          {
-            Debug.LogError($"Connection to {host} timed out.");
-          }
-          OnConnected -= SetConnectedComplete;
-          OnConnectionFailed(hostSteamID);
+            ConnectionTimeout = TimeSpan.FromSeconds(Math.Max(1, transport.Timeout));
         }
 
-        OnConnected -= SetConnectedComplete;
-      }
-      catch (FormatException)
-      {
-        Debug.LogError($"Connection string was not in the right format. Did you enter a SteamId?");
-        Error = true;
-        OnConnectionFailed(hostSteamID);
-      }
-      catch (Exception ex)
-      {
-        Debug.LogError(ex.Message);
-        Error = true;
-        OnConnectionFailed(hostSteamID);
-      }
-      finally
-      {
-        if (Error)
+        public static LegacyClient CreateClient(FizzySteamworks transport, string host)
         {
-          OnConnectionFailed(CSteamID.Nil);
+            LegacyClient c = new LegacyClient(transport);
+
+            c.OnConnected += () => transport.OnClientConnected.Invoke();
+            c.OnDisconnected += () => transport.OnClientDisconnected.Invoke();
+            c.OnReceivedData += (data, channel) => transport.OnClientDataReceived.Invoke(new ArraySegment<byte>(data), channel);
+
+
+            try
+            {
+#if UNITY_SERVER
+                InteropHelp.TestIfAvailableGameServer();
+#else
+                InteropHelp.TestIfAvailableClient();
+#endif
+                c.Connect(host);
+            }
+            catch
+            {
+                Debug.LogError("SteamWorks not initialized.");
+                c.OnConnectionFailed(CSteamID.Nil);
+            }
+
+            return c;
         }
-      }
+
+        private async void Connect(string host)
+        {
+            cancelToken = new CancellationTokenSource();
+
+            try
+            {
+                hostSteamID = new CSteamID(UInt64.Parse(host));
+                connectedComplete = new TaskCompletionSource<Task>();
+
+                OnConnected += SetConnectedComplete;
+
+                SendInternal(hostSteamID, InternalMessages.CONNECT);
+
+                Task connectedCompleteTask = connectedComplete.Task;
+                Task timeOutTask = Task.Delay(ConnectionTimeout, cancelToken.Token);
+
+                if (await Task.WhenAny(connectedCompleteTask, timeOutTask) != connectedCompleteTask)
+                {
+                    if (cancelToken.IsCancellationRequested)
+                    {
+                        Debug.LogError($"The connection attempt was cancelled.");
+                    }
+                    else if (timeOutTask.IsCompleted)
+                    {
+                        Debug.LogError($"Connection to {host} timed out.");
+                    }
+                    OnConnected -= SetConnectedComplete;
+                    OnConnectionFailed(hostSteamID);
+                }
+
+                OnConnected -= SetConnectedComplete;
+            }
+            catch (FormatException)
+            {
+                Debug.LogError($"Connection string was not in the right format. Did you enter a SteamId?");
+                Error = true;
+                OnConnectionFailed(hostSteamID);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError(ex.Message);
+                Error = true;
+                OnConnectionFailed(hostSteamID);
+            }
+            finally
+            {
+                if (Error)
+                {
+                    OnConnectionFailed(CSteamID.Nil);
+                }
+            }
+        }
+
+        public void Disconnect()
+        {
+            Debug.Log("Sending Disconnect message");
+            SendInternal(hostSteamID, InternalMessages.DISCONNECT);
+            Dispose();
+            cancelToken?.Cancel();
+
+            WaitForClose(hostSteamID);
+        }
+
+        private void SetConnectedComplete() => connectedComplete.SetResult(connectedComplete.Task);
+
+        protected override void OnReceiveData(byte[] data, CSteamID clientSteamID, int channel)
+        {
+            if (clientSteamID != hostSteamID)
+            {
+                Debug.LogError("Received a message from an unknown");
+                return;
+            }
+
+            OnReceivedData.Invoke(data, channel);
+        }
+
+        protected override void OnNewConnection(P2PSessionRequest_t result)
+        {
+            if (hostSteamID == result.m_steamIDRemote)
+            {
+                SteamNetworking.AcceptP2PSessionWithUser(result.m_steamIDRemote);
+            }
+            else
+            {
+                Debug.LogError("P2P Acceptance Request from unknown host ID.");
+            }
+        }
+
+        protected override void OnReceiveInternalData(InternalMessages type, CSteamID clientSteamID)
+        {
+            switch (type)
+            {
+                case InternalMessages.ACCEPT_CONNECT:
+                    if (!Connected)
+                    {
+                        Connected = true;
+                        OnConnected.Invoke();
+                        Debug.Log("Connection established.");
+                    }
+                    break;
+                case InternalMessages.DISCONNECT:
+                    if (Connected)
+                    {
+                        Connected = false;
+                        Debug.Log("Disconnected.");
+                        OnDisconnected.Invoke();
+                    }
+                    break;
+                default:
+                    Debug.Log("Received unknown message type");
+                    break;
+            }
+        }
+
+        public void Send(byte[] data, int channelId) => Send(hostSteamID, data, channelId);
+
+        protected override void OnConnectionFailed(CSteamID remoteId) => OnDisconnected.Invoke();
+        public void FlushData() { }
     }
-
-    public void Disconnect()
-    {
-      Debug.Log("Sending Disconnect message");
-      SendInternal(hostSteamID, InternalMessages.DISCONNECT);
-      Dispose();
-      cancelToken?.Cancel();
-
-      WaitForClose(hostSteamID);
-    }
-
-    private void SetConnectedComplete() => connectedComplete.SetResult(connectedComplete.Task);
-
-    protected override void OnReceiveData(byte[] data, CSteamID clientSteamID, int channel)
-    {
-      if (clientSteamID != hostSteamID)
-      {
-        Debug.LogError("Received a message from an unknown");
-        return;
-      }
-
-      OnReceivedData.Invoke(data, channel);
-    }
-
-    protected override void OnNewConnection(P2PSessionRequest_t result)
-    {
-      if (hostSteamID == result.m_steamIDRemote)
-      {
-        SteamNetworking.AcceptP2PSessionWithUser(result.m_steamIDRemote);
-      }
-      else
-      {
-        Debug.LogError("P2P Acceptance Request from unknown host ID.");
-      }
-    }
-
-    protected override void OnReceiveInternalData(InternalMessages type, CSteamID clientSteamID)
-    {
-      switch (type)
-      {
-        case InternalMessages.ACCEPT_CONNECT:
-          if (!Connected)
-          {
-            Connected = true;
-            OnConnected.Invoke();
-            Debug.Log("Connection established.");
-          }
-          break;
-        case InternalMessages.DISCONNECT:
-          if (Connected)
-          {
-            Connected = false;
-            Debug.Log("Disconnected.");
-            OnDisconnected.Invoke();
-          }
-          break;
-        default:
-          Debug.Log("Received unknown message type");
-          break;
-      }
-    }
-
-    public void Send(byte[] data, int channelId) => Send(hostSteamID, data, channelId);
-
-    protected override void OnConnectionFailed(CSteamID remoteId) => OnDisconnected.Invoke();
-    public void FlushData() { }
-  }
 }
 #endif // !DISABLESTEAMWORKS

--- a/LegacyCommon.cs
+++ b/LegacyCommon.cs
@@ -6,146 +6,175 @@ using UnityEngine;
 
 namespace Mirror.FizzySteam
 {
-  public abstract class LegacyCommon
-  {
-    private EP2PSend[] channels;
-    private int internal_ch => channels.Length;
-
-    protected enum InternalMessages : byte
+    public abstract class LegacyCommon
     {
-      CONNECT,
-      ACCEPT_CONNECT,
-      DISCONNECT
-    }
+        private EP2PSend[] channels;
+        private int internal_ch => channels.Length;
 
-    private Callback<P2PSessionRequest_t> callback_OnNewConnection = null;
-    private Callback<P2PSessionConnectFail_t> callback_OnConnectFail = null;
-
-    protected readonly FizzySteamworks transport;
-
-    protected LegacyCommon(FizzySteamworks transport)
-    {
-      channels = transport.Channels;
-
-      callback_OnNewConnection = Callback<P2PSessionRequest_t>.Create(OnNewConnection);
-      callback_OnConnectFail = Callback<P2PSessionConnectFail_t>.Create(OnConnectFail);
-
-      this.transport = transport;
-    }
-
-    protected void Dispose()
-    {
-      if (callback_OnNewConnection != null)
-      {
-        callback_OnNewConnection.Dispose();
-        callback_OnNewConnection = null;
-      }
-
-      if (callback_OnConnectFail != null)
-      {
-        callback_OnConnectFail.Dispose();
-        callback_OnConnectFail = null;
-      }
-    }
-
-    protected abstract void OnNewConnection(P2PSessionRequest_t result);
-
-    private void OnConnectFail(P2PSessionConnectFail_t result)
-    {
-      OnConnectionFailed(result.m_steamIDRemote);
-      CloseP2PSessionWithUser(result.m_steamIDRemote);
-
-      switch (result.m_eP2PSessionError)
-      {
-        case 1:
-          Debug.LogError("Connection failed: The target user is not running the same game.");
-          break;
-        case 2:
-          Debug.LogError("Connection failed: The local user doesn't own the app that is running.");
-          break;
-        case 3:
-          Debug.LogError("Connection failed: Target user isn't connected to Steam.");
-          break;
-        case 4:
-          Debug.LogError("Connection failed: The connection timed out because the target user didn't respond.");
-          break;
-        default:
-          Debug.LogError("Connection failed: Unknown error.");
-          break;
-      }
-    }
-
-    protected void SendInternal(CSteamID target, InternalMessages type) => SteamNetworking.SendP2PPacket(target, new byte[] { (byte)type }, 1, EP2PSend.k_EP2PSendReliable, internal_ch);
-    protected void Send(CSteamID host, byte[] msgBuffer, int channel) => SteamNetworking.SendP2PPacket(host, msgBuffer, (uint)msgBuffer.Length, channels[Mathf.Min(channel, channels.Length - 1)], channel);
-
-    private bool Receive(out CSteamID clientSteamID, out byte[] receiveBuffer, int channel)
-    {
-      if (SteamNetworking.IsP2PPacketAvailable(out uint packetSize, channel))
-      {
-        receiveBuffer = new byte[packetSize];
-        return SteamNetworking.ReadP2PPacket(receiveBuffer, packetSize, out _, out clientSteamID, channel);
-      }
-
-      receiveBuffer = null;
-      clientSteamID = CSteamID.Nil;
-      return false;
-    }
-
-    protected void CloseP2PSessionWithUser(CSteamID clientSteamID) => SteamNetworking.CloseP2PSessionWithUser(clientSteamID);
-
-    protected void WaitForClose(CSteamID cSteamID)
-    {
-      if (transport.enabled)
-      {
-        transport.StartCoroutine(DelayedClose(cSteamID));
-      }
-      else
-      {
-        CloseP2PSessionWithUser(cSteamID);
-      }
-    }
-
-    private IEnumerator DelayedClose(CSteamID cSteamID)
-    {
-      yield return null;
-      CloseP2PSessionWithUser(cSteamID);
-    }
-
-    public void ReceiveData()
-    {
-      try
-      {
-        while (transport.enabled && Receive(out CSteamID clientSteamID, out byte[] internalMessage, internal_ch))
+        protected enum InternalMessages : byte
         {
-          if (internalMessage.Length == 1)
-          {
-            OnReceiveInternalData((InternalMessages)internalMessage[0], clientSteamID);
-            return; // Wait one frame
-          }
-          else
-          {
-            Debug.Log("Incorrect package length on internal channel.");
-          }
+            CONNECT,
+            ACCEPT_CONNECT,
+            DISCONNECT
         }
 
-        for (int chNum = 0; chNum < channels.Length; chNum++)
+        private Callback<P2PSessionRequest_t> callback_OnNewConnection = null;
+        private Callback<P2PSessionConnectFail_t> callback_OnConnectFail = null;
+
+        protected readonly FizzySteamworks transport;
+
+        protected LegacyCommon(FizzySteamworks transport)
         {
-          while (transport.enabled && Receive(out CSteamID clientSteamID, out byte[] receiveBuffer, chNum))
-          {
-            OnReceiveData(receiveBuffer, clientSteamID, chNum);
-          }
+            channels = transport.Channels;
+
+            callback_OnNewConnection = Callback<P2PSessionRequest_t>.Create(OnNewConnection);
+            callback_OnConnectFail = Callback<P2PSessionConnectFail_t>.Create(OnConnectFail);
+
+            this.transport = transport;
         }
 
-      }
-      catch (Exception e)
-      {
-        Debug.LogException(e);
-      }
-    }
+        protected void Dispose()
+        {
+            if (callback_OnNewConnection != null)
+            {
+                callback_OnNewConnection.Dispose();
+                callback_OnNewConnection = null;
+            }
 
-    protected abstract void OnReceiveInternalData(InternalMessages type, CSteamID clientSteamID);
-    protected abstract void OnReceiveData(byte[] data, CSteamID clientSteamID, int channel);
-    protected abstract void OnConnectionFailed(CSteamID remoteId);
-  }
+            if (callback_OnConnectFail != null)
+            {
+                callback_OnConnectFail.Dispose();
+                callback_OnConnectFail = null;
+            }
+        }
+
+        protected abstract void OnNewConnection(P2PSessionRequest_t result);
+
+        private void OnConnectFail(P2PSessionConnectFail_t result)
+        {
+            OnConnectionFailed(result.m_steamIDRemote);
+            CloseP2PSessionWithUser(result.m_steamIDRemote);
+
+            switch (result.m_eP2PSessionError)
+            {
+                case 1:
+                    Debug.LogError("Connection failed: The target user is not running the same game.");
+                    break;
+                case 2:
+                    Debug.LogError("Connection failed: The local user doesn't own the app that is running.");
+                    break;
+                case 3:
+                    Debug.LogError("Connection failed: Target user isn't connected to Steam.");
+                    break;
+                case 4:
+                    Debug.LogError("Connection failed: The connection timed out because the target user didn't respond.");
+                    break;
+                default:
+                    Debug.LogError("Connection failed: Unknown error.");
+                    break;
+            }
+        }
+
+        protected void SendInternal(CSteamID target, InternalMessages type)
+        {
+#if UNITY_SERVER
+            SteamGameServerNetworking.SendP2PPacket(target, new byte[] { (byte)type }, 1, EP2PSend.k_EP2PSendReliable, internal_ch);
+#else
+            SteamNetworking.SendP2PPacket(target, new byte[] { (byte)type }, 1, EP2PSend.k_EP2PSendReliable, internal_ch);
+#endif
+        }
+        protected void Send(CSteamID host, byte[] msgBuffer, int channel)
+        {
+#if UNITY_SERVER
+            SteamGameServerNetworking.SendP2PPacket(host, msgBuffer, (uint)msgBuffer.Length, channels[Mathf.Min(channel, channels.Length - 1)], channel);
+#else
+            SteamNetworking.SendP2PPacket(host, msgBuffer, (uint)msgBuffer.Length, channels[Mathf.Min(channel, channels.Length - 1)], channel);
+#endif
+        }
+
+        private bool Receive(out CSteamID clientSteamID, out byte[] receiveBuffer, int channel)
+        {
+#if UNITY_SERVER
+            if (SteamGameServerNetworking.IsP2PPacketAvailable(out uint packetSize, channel))
+            {
+                receiveBuffer = new byte[packetSize];
+                return SteamGameServerNetworking.ReadP2PPacket(receiveBuffer, packetSize, out _, out clientSteamID, channel);
+            }
+#else
+            if (SteamNetworking.IsP2PPacketAvailable(out uint packetSize, channel))
+            {
+                receiveBuffer = new byte[packetSize];
+                return SteamNetworking.ReadP2PPacket(receiveBuffer, packetSize, out _, out clientSteamID, channel);
+            }
+#endif
+
+            receiveBuffer = null;
+            clientSteamID = CSteamID.Nil;
+            return false;
+        }
+
+        protected void CloseP2PSessionWithUser(CSteamID clientSteamID)
+        {
+#if UNITY_SERVER
+            SteamGameServerNetworking.CloseP2PSessionWithUser(clientSteamID);
+#else
+            SteamNetworking.CloseP2PSessionWithUser(clientSteamID);
+#endif
+        }
+
+        protected void WaitForClose(CSteamID cSteamID)
+        {
+            if (transport.enabled)
+            {
+                transport.StartCoroutine(DelayedClose(cSteamID));
+            }
+            else
+            {
+                CloseP2PSessionWithUser(cSteamID);
+            }
+        }
+
+        private IEnumerator DelayedClose(CSteamID cSteamID)
+        {
+            yield return null;
+            CloseP2PSessionWithUser(cSteamID);
+        }
+
+        public void ReceiveData()
+        {
+            try
+            {
+                while (transport.enabled && Receive(out CSteamID clientSteamID, out byte[] internalMessage, internal_ch))
+                {
+                    if (internalMessage.Length == 1)
+                    {
+                        OnReceiveInternalData((InternalMessages)internalMessage[0], clientSteamID);
+                        return; // Wait one frame
+                    }
+                    else
+                    {
+                        Debug.Log("Incorrect package length on internal channel.");
+                    }
+                }
+
+                for (int chNum = 0; chNum < channels.Length; chNum++)
+                {
+                    while (transport.enabled && Receive(out CSteamID clientSteamID, out byte[] receiveBuffer, chNum))
+                    {
+                        OnReceiveData(receiveBuffer, clientSteamID, chNum);
+                    }
+                }
+
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+            }
+        }
+
+        protected abstract void OnReceiveInternalData(InternalMessages type, CSteamID clientSteamID);
+        protected abstract void OnReceiveData(byte[] data, CSteamID clientSteamID, int channel);
+        protected abstract void OnConnectionFailed(CSteamID remoteId);
+    }
 }
 #endif // !DISABLESTEAMWORKS

--- a/LegacyServer.cs
+++ b/LegacyServer.cs
@@ -6,150 +6,165 @@ using UnityEngine;
 
 namespace Mirror.FizzySteam
 {
-  public class LegacyServer : LegacyCommon, IServer
-  {
-    private event Action<int> OnConnected;
-    private event Action<int, byte[], int> OnReceivedData;
-    private event Action<int> OnDisconnected;
-    private event Action<int, Exception> OnReceivedError;
-
-    private BidirectionalDictionary<CSteamID, int> steamToMirrorIds;
-    private int maxConnections;
-    private int nextConnectionID;
-
-    public static LegacyServer CreateServer(FizzySteamworks transport, int maxConnections)
+    public class LegacyServer : LegacyCommon, IServer
     {
-      LegacyServer s = new LegacyServer(transport, maxConnections);
+        private event Action<int> OnConnected;
+        private event Action<int, byte[], int> OnReceivedData;
+        private event Action<int> OnDisconnected;
+        private event Action<int, Exception> OnReceivedError;
 
-      s.OnConnected += (id) => transport.OnServerConnected.Invoke(id);
-      s.OnDisconnected += (id) => transport.OnServerDisconnected.Invoke(id);
-      s.OnReceivedData += (id, data, channel) => transport.OnServerDataReceived.Invoke(id, new ArraySegment<byte>(data), channel);
-      s.OnReceivedError += (id, exception) => transport.OnServerError.Invoke(id, exception);
+        private BidirectionalDictionary<CSteamID, int> steamToMirrorIds;
+        private int maxConnections;
+        private int nextConnectionID;
 
-      if (!SteamManager.Initialized)
-      {
-        Debug.LogError("SteamWorks not initialized.");
-      }
+        public static LegacyServer CreateServer(FizzySteamworks transport, int maxConnections)
+        {
+            LegacyServer s = new LegacyServer(transport, maxConnections);
 
-      return s;
+            s.OnConnected += (id) => transport.OnServerConnected.Invoke(id);
+            s.OnDisconnected += (id) => transport.OnServerDisconnected.Invoke(id);
+            s.OnReceivedData += (id, data, channel) => transport.OnServerDataReceived.Invoke(id, new ArraySegment<byte>(data), channel);
+            s.OnReceivedError += (id, exception) => transport.OnServerError.Invoke(id, exception);
+
+            try
+            {
+#if UNITY_SERVER
+                InteropHelp.TestIfAvailableGameServer();
+#else
+                InteropHelp.TestIfAvailableClient();
+#endif
+            }
+            catch
+            {
+                Debug.LogError("SteamWorks not initialized.");
+            }
+
+            return s;
+        }
+
+        private LegacyServer(FizzySteamworks transport, int maxConnections) : base(transport)
+        {
+            this.maxConnections = maxConnections;
+            steamToMirrorIds = new BidirectionalDictionary<CSteamID, int>();
+            nextConnectionID = 1;
+        }
+
+        protected override void OnNewConnection(P2PSessionRequest_t result)
+        {
+#if UNITY_SERVER
+            SteamGameServerNetworking.AcceptP2PSessionWithUser(result.m_steamIDRemote);
+#else
+            SteamNetworking.AcceptP2PSessionWithUser(result.m_steamIDRemote);
+#endif
+        }
+
+        protected override void OnReceiveInternalData(InternalMessages type, CSteamID clientSteamID)
+        {
+            switch (type)
+            {
+                case InternalMessages.CONNECT:
+                    if (steamToMirrorIds.Count >= maxConnections)
+                    {
+                        SendInternal(clientSteamID, InternalMessages.DISCONNECT);
+                        return;
+                    }
+
+                    SendInternal(clientSteamID, InternalMessages.ACCEPT_CONNECT);
+
+                    int connectionId = nextConnectionID++;
+                    steamToMirrorIds.Add(clientSteamID, connectionId);
+                    OnConnected.Invoke(connectionId);
+                    Debug.Log($"Client with SteamID {clientSteamID} connected. Assigning connection id {connectionId}");
+                    break;
+                case InternalMessages.DISCONNECT:
+                    if (steamToMirrorIds.TryGetValue(clientSteamID, out int connId))
+                    {
+                        OnDisconnected.Invoke(connId);
+                        CloseP2PSessionWithUser(clientSteamID);
+                        steamToMirrorIds.Remove(clientSteamID);
+                        Debug.Log($"Client with SteamID {clientSteamID} disconnected.");
+                    }
+
+                    break;
+                default:
+                    Debug.Log("Received unknown message type");
+                    break;
+            }
+        }
+
+        protected override void OnReceiveData(byte[] data, CSteamID clientSteamID, int channel)
+        {
+            if (steamToMirrorIds.TryGetValue(clientSteamID, out int connectionId))
+            {
+                OnReceivedData.Invoke(connectionId, data, channel);
+            }
+            else
+            {
+                CloseP2PSessionWithUser(clientSteamID);
+                Debug.LogError("Data received from steam client thats not known " + clientSteamID);
+                OnReceivedError.Invoke(-1, new Exception("ERROR Unknown SteamID"));
+            }
+        }
+
+        public void Disconnect(int connectionId)
+        {
+            if (steamToMirrorIds.TryGetValue(connectionId, out CSteamID steamID))
+            {
+                SendInternal(steamID, InternalMessages.DISCONNECT);
+                steamToMirrorIds.Remove(connectionId);
+            }
+            else
+            {
+                Debug.LogWarning("Trying to disconnect unknown connection id: " + connectionId);
+            }
+        }
+
+        public void Shutdown()
+        {
+            foreach (KeyValuePair<CSteamID, int> client in steamToMirrorIds)
+            {
+                Disconnect(client.Value);
+                WaitForClose(client.Key);
+            }
+
+            Dispose();
+        }
+
+        public void Send(int connectionId, byte[] data, int channelId)
+        {
+            if (steamToMirrorIds.TryGetValue(connectionId, out CSteamID steamId))
+            {
+                Send(steamId, data, channelId);
+            }
+            else
+            {
+                Debug.LogError("Trying to send on unknown connection: " + connectionId);
+                OnReceivedError.Invoke(connectionId, new Exception("ERROR Unknown Connection"));
+            }
+        }
+
+        public string ServerGetClientAddress(int connectionId)
+        {
+            if (steamToMirrorIds.TryGetValue(connectionId, out CSteamID steamId))
+            {
+                return steamId.ToString();
+            }
+            else
+            {
+                Debug.LogError("Trying to get info on unknown connection: " + connectionId);
+                OnReceivedError.Invoke(connectionId, new Exception("ERROR Unknown Connection"));
+                return string.Empty;
+            }
+        }
+
+        protected override void OnConnectionFailed(CSteamID remoteId)
+        {
+            int connectionId = steamToMirrorIds.TryGetValue(remoteId, out int connId) ? connId : nextConnectionID++;
+            OnDisconnected.Invoke(connectionId);
+
+            steamToMirrorIds.Remove(remoteId);
+        }
+        public void FlushData() { }
     }
-
-    private LegacyServer(FizzySteamworks transport, int maxConnections) : base(transport)
-    {
-      this.maxConnections = maxConnections;
-      steamToMirrorIds = new BidirectionalDictionary<CSteamID, int>();
-      nextConnectionID = 1;
-    }
-
-    protected override void OnNewConnection(P2PSessionRequest_t result) => SteamNetworking.AcceptP2PSessionWithUser(result.m_steamIDRemote);
-
-    protected override void OnReceiveInternalData(InternalMessages type, CSteamID clientSteamID)
-    {
-      switch (type)
-      {
-        case InternalMessages.CONNECT:
-          if (steamToMirrorIds.Count >= maxConnections)
-          {
-            SendInternal(clientSteamID, InternalMessages.DISCONNECT);
-            return;
-          }
-
-          SendInternal(clientSteamID, InternalMessages.ACCEPT_CONNECT);
-
-          int connectionId = nextConnectionID++;
-          steamToMirrorIds.Add(clientSteamID, connectionId);
-          OnConnected.Invoke(connectionId);
-          Debug.Log($"Client with SteamID {clientSteamID} connected. Assigning connection id {connectionId}");
-          break;
-        case InternalMessages.DISCONNECT:
-          if (steamToMirrorIds.TryGetValue(clientSteamID, out int connId))
-          {
-            OnDisconnected.Invoke(connId);
-            CloseP2PSessionWithUser(clientSteamID);
-            steamToMirrorIds.Remove(clientSteamID);
-            Debug.Log($"Client with SteamID {clientSteamID} disconnected.");
-          }
-
-          break;
-        default:
-          Debug.Log("Received unknown message type");
-          break;
-      }
-    }
-
-    protected override void OnReceiveData(byte[] data, CSteamID clientSteamID, int channel)
-    {
-      if (steamToMirrorIds.TryGetValue(clientSteamID, out int connectionId))
-      {
-        OnReceivedData.Invoke(connectionId, data, channel);
-      }
-      else
-      {
-        CloseP2PSessionWithUser(clientSteamID);
-        Debug.LogError("Data received from steam client thats not known " + clientSteamID);
-        OnReceivedError.Invoke(-1, new Exception("ERROR Unknown SteamID"));
-      }
-    }
-
-    public void Disconnect(int connectionId)
-    {
-      if (steamToMirrorIds.TryGetValue(connectionId, out CSteamID steamID))
-      {
-        SendInternal(steamID, InternalMessages.DISCONNECT);
-        steamToMirrorIds.Remove(connectionId);
-      }
-      else
-      {
-        Debug.LogWarning("Trying to disconnect unknown connection id: " + connectionId);
-      }
-    }
-
-    public void Shutdown()
-    {
-      foreach (KeyValuePair<CSteamID, int> client in steamToMirrorIds)
-      {
-        Disconnect(client.Value);
-        WaitForClose(client.Key);
-      }
-
-      Dispose();
-    }
-
-    public void Send(int connectionId, byte[] data, int channelId)
-    {
-      if (steamToMirrorIds.TryGetValue(connectionId, out CSteamID steamId))
-      {
-        Send(steamId, data, channelId);
-      }
-      else
-      {
-        Debug.LogError("Trying to send on unknown connection: " + connectionId);
-        OnReceivedError.Invoke(connectionId, new Exception("ERROR Unknown Connection"));
-      }
-    }
-
-    public string ServerGetClientAddress(int connectionId)
-    {
-      if (steamToMirrorIds.TryGetValue(connectionId, out CSteamID steamId))
-      {
-        return steamId.ToString();
-      }
-      else
-      {
-        Debug.LogError("Trying to get info on unknown connection: " + connectionId);
-        OnReceivedError.Invoke(connectionId, new Exception("ERROR Unknown Connection"));
-        return string.Empty;
-      }
-    }
-
-    protected override void OnConnectionFailed(CSteamID remoteId)
-    {
-      int connectionId = steamToMirrorIds.TryGetValue(remoteId, out int connId) ? connId : nextConnectionID++;
-      OnDisconnected.Invoke(connectionId);
-
-      steamToMirrorIds.Remove(remoteId);
-    }
-    public void FlushData() { }
-  }
 }
 #endif // !DISABLESTEAMWORKS

--- a/NextClient.cs
+++ b/NextClient.cs
@@ -8,214 +8,219 @@ using UnityEngine;
 
 namespace Mirror.FizzySteam
 {
-  public class NextClient : NextCommon, IClient
-  {
-    public bool Connected { get; private set; }
-    public bool Error { get; private set; }
-
-    private TimeSpan ConnectionTimeout;
-
-    private event Action<byte[], int> OnReceivedData;
-    private event Action OnConnected;
-    private event Action OnDisconnected;
-    private Callback<SteamNetConnectionStatusChangedCallback_t> c_onConnectionChange = null;
-
-    private CancellationTokenSource cancelToken;
-    private TaskCompletionSource<Task> connectedComplete;
-    private CSteamID hostSteamID = CSteamID.Nil;
-    private HSteamNetConnection HostConnection;
-    private List<Action> BufferedData;
-
-    private NextClient(FizzySteamworks transport)
+    public class NextClient : NextCommon, IClient
     {
-      ConnectionTimeout = TimeSpan.FromSeconds(Math.Max(1, transport.Timeout));
-      BufferedData = new List<Action>();
-    }
+        public bool Connected { get; private set; }
+        public bool Error { get; private set; }
 
-    public static NextClient CreateClient(FizzySteamworks transport, string host)
-    {
-      NextClient c = new NextClient(transport);
+        private TimeSpan ConnectionTimeout;
 
-      c.OnConnected += () => transport.OnClientConnected.Invoke();
-      c.OnDisconnected += () => transport.OnClientDisconnected.Invoke();
-      c.OnReceivedData += (data, ch) => transport.OnClientDataReceived.Invoke(new ArraySegment<byte>(data), ch);
+        private event Action<byte[], int> OnReceivedData;
+        private event Action OnConnected;
+        private event Action OnDisconnected;
+        private Callback<SteamNetConnectionStatusChangedCallback_t> c_onConnectionChange = null;
 
-      if (SteamManager.Initialized)
-      {
-        c.Connect(host);
-      }
-      else
-      {
-        Debug.LogError("SteamWorks not initialized");
-        c.OnConnectionFailed();
-      }
+        private CancellationTokenSource cancelToken;
+        private TaskCompletionSource<Task> connectedComplete;
+        private CSteamID hostSteamID = CSteamID.Nil;
+        private HSteamNetConnection HostConnection;
+        private List<Action> BufferedData;
 
-      return c;
-    }
-
-    private async void Connect(string host)
-    {
-      cancelToken = new CancellationTokenSource();
-      c_onConnectionChange = Callback<SteamNetConnectionStatusChangedCallback_t>.Create(OnConnectionStatusChanged);
-
-      try
-      {
-        hostSteamID = new CSteamID(UInt64.Parse(host));
-        connectedComplete = new TaskCompletionSource<Task>();
-        OnConnected += SetConnectedComplete;
-
-        SteamNetworkingIdentity smi = new SteamNetworkingIdentity();
-        smi.SetSteamID(hostSteamID);
-
-        SteamNetworkingConfigValue_t[] options = new SteamNetworkingConfigValue_t[] { };
-        HostConnection = SteamNetworkingSockets.ConnectP2P(ref smi, 0, options.Length, options);
-
-        Task connectedCompleteTask = connectedComplete.Task;
-        Task timeOutTask = Task.Delay(ConnectionTimeout, cancelToken.Token);
-
-        if (await Task.WhenAny(connectedCompleteTask, timeOutTask) != connectedCompleteTask)
+        private NextClient(FizzySteamworks transport)
         {
-          if (cancelToken.IsCancellationRequested)
-          {
-            Debug.LogError($"The connection attempt was cancelled.");
-          }
-          else if (timeOutTask.IsCompleted)
-          {
-            Debug.LogError($"Connection to {host} timed out.");
-          }
-
-          OnConnected -= SetConnectedComplete;
-          OnConnectionFailed();
+            ConnectionTimeout = TimeSpan.FromSeconds(Math.Max(1, transport.Timeout));
+            BufferedData = new List<Action>();
         }
 
-        OnConnected -= SetConnectedComplete;
-      }
-      catch (FormatException)
-      {
-        Debug.LogError($"Connection string was not in the right format. Did you enter a SteamId?");
-        Error = true;
-        OnConnectionFailed();
-      }
-      catch (Exception ex)
-      {
-        Debug.LogError(ex.Message);
-        Error = true;
-        OnConnectionFailed();
-      }
-      finally
-      {
-        if (Error)
+        public static NextClient CreateClient(FizzySteamworks transport, string host)
         {
-          Debug.LogError("Connection failed.");
-          OnConnectionFailed();
-        }
-      }
-    }
+            NextClient c = new NextClient(transport);
 
-    private void OnConnectionStatusChanged(SteamNetConnectionStatusChangedCallback_t param)
-    {
-      ulong clientSteamID = param.m_info.m_identityRemote.GetSteamID64();
-      if (param.m_info.m_eState == ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_Connected)
-      {
-        Connected = true;
-        OnConnected.Invoke();
-        Debug.Log("Connection established.");
+            c.OnConnected += () => transport.OnClientConnected.Invoke();
+            c.OnDisconnected += () => transport.OnClientDisconnected.Invoke();
+            c.OnReceivedData += (data, ch) => transport.OnClientDataReceived.Invoke(new ArraySegment<byte>(data), ch);
 
-        if (BufferedData.Count > 0)
-        {
-          Debug.Log($"{BufferedData.Count} received before connection was established. Processing now.");
-          {
-            foreach (Action a in BufferedData)
+            try
             {
-              a();
+#if UNITY_SERVER
+                SteamGameServerNetworkingUtils.InitRelayNetworkAccess();
+#else
+                SteamNetworkingUtils.InitRelayNetworkAccess();
+#endif
+                c.Connect(host);
             }
-          }
+            catch (Exception ex)
+            {
+                Debug.LogException(ex);
+                c.OnConnectionFailed();
+            }
+
+            return c;
         }
-      }
-      else if (param.m_info.m_eState == ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ClosedByPeer || param.m_info.m_eState == ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ProblemDetectedLocally)
-      {
-        Debug.Log($"Connection was closed by peer, {param.m_info.m_szEndDebug}");
-        Disconnect();
-      }
-      else
-      {
-        Debug.Log($"Connection state changed: {param.m_info.m_eState.ToString()} - {param.m_info.m_szEndDebug}");
-      }
-    }
 
-    public void Disconnect()
-    {
-      cancelToken?.Cancel();
-      Dispose();
-
-      if (HostConnection.m_HSteamNetConnection != 0)
-      {
-        Debug.Log("Sending Disconnect message");
-        SteamNetworkingSockets.CloseConnection(HostConnection, 0, "Graceful disconnect", false);
-        HostConnection.m_HSteamNetConnection = 0;
-      }
-    }
-
-    protected void Dispose()
-    {
-      if (c_onConnectionChange != null)
-      {
-        c_onConnectionChange.Dispose();
-        c_onConnectionChange = null;
-      }
-    }
-
-    private void InternalDisconnect()
-    {
-      Connected = false;
-      OnDisconnected.Invoke();
-      Debug.Log("Disconnected.");
-      SteamNetworkingSockets.CloseConnection(HostConnection, 0, "Disconnected", false);
-    }
-
-    public void ReceiveData()
-    {
-      IntPtr[] ptrs = new IntPtr[MAX_MESSAGES];
-      int messageCount;
-
-      if ((messageCount = SteamNetworkingSockets.ReceiveMessagesOnConnection(HostConnection, ptrs, MAX_MESSAGES)) > 0)
-      {
-        for (int i = 0; i < messageCount; i++)
+        private async void Connect(string host)
         {
-          (byte[] data, int ch) = ProcessMessage(ptrs[i]);
-          if (Connected)
-          {
-            OnReceivedData(data, ch);
-          }
-          else
-          {
-            BufferedData.Add(() => OnReceivedData(data, ch));
-          }
+            cancelToken = new CancellationTokenSource();
+            c_onConnectionChange = Callback<SteamNetConnectionStatusChangedCallback_t>.Create(OnConnectionStatusChanged);
+
+            try
+            {
+                hostSteamID = new CSteamID(UInt64.Parse(host));
+                connectedComplete = new TaskCompletionSource<Task>();
+                OnConnected += SetConnectedComplete;
+
+                SteamNetworkingIdentity smi = new SteamNetworkingIdentity();
+                smi.SetSteamID(hostSteamID);
+
+                SteamNetworkingConfigValue_t[] options = new SteamNetworkingConfigValue_t[] { };
+                HostConnection = SteamNetworkingSockets.ConnectP2P(ref smi, 0, options.Length, options);
+
+                Task connectedCompleteTask = connectedComplete.Task;
+                Task timeOutTask = Task.Delay(ConnectionTimeout, cancelToken.Token);
+
+                if (await Task.WhenAny(connectedCompleteTask, timeOutTask) != connectedCompleteTask)
+                {
+                    if (cancelToken.IsCancellationRequested)
+                    {
+                        Debug.LogError($"The connection attempt was cancelled.");
+                    }
+                    else if (timeOutTask.IsCompleted)
+                    {
+                        Debug.LogError($"Connection to {host} timed out.");
+                    }
+
+                    OnConnected -= SetConnectedComplete;
+                    OnConnectionFailed();
+                }
+
+                OnConnected -= SetConnectedComplete;
+            }
+            catch (FormatException)
+            {
+                Debug.LogError($"Connection string was not in the right format. Did you enter a SteamId?");
+                Error = true;
+                OnConnectionFailed();
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError(ex.Message);
+                Error = true;
+                OnConnectionFailed();
+            }
+            finally
+            {
+                if (Error)
+                {
+                    Debug.LogError("Connection failed.");
+                    OnConnectionFailed();
+                }
+            }
         }
-      }
-    }
 
-    public void Send(byte[] data, int channelId)
-    {
-      EResult res = SendSocket(HostConnection, data, channelId);
+        private void OnConnectionStatusChanged(SteamNetConnectionStatusChangedCallback_t param)
+        {
+            ulong clientSteamID = param.m_info.m_identityRemote.GetSteamID64();
+            if (param.m_info.m_eState == ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_Connected)
+            {
+                Connected = true;
+                OnConnected.Invoke();
+                Debug.Log("Connection established.");
 
-      if(res == EResult.k_EResultNoConnection || res == EResult.k_EResultInvalidParam)
-      {
-        Debug.Log($"Connection to server was lost.");
-        InternalDisconnect();
-      }
-      else if (res != EResult.k_EResultOK)
-      {
-        Debug.LogError($"Could not send: {res.ToString()}");
-      }
-    }
+                if (BufferedData.Count > 0)
+                {
+                    Debug.Log($"{BufferedData.Count} received before connection was established. Processing now.");
+                    {
+                        foreach (Action a in BufferedData)
+                        {
+                            a();
+                        }
+                    }
+                }
+            }
+            else if (param.m_info.m_eState == ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ClosedByPeer || param.m_info.m_eState == ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ProblemDetectedLocally)
+            {
+                Debug.Log($"Connection was closed by peer, {param.m_info.m_szEndDebug}");
+                Disconnect();
+            }
+            else
+            {
+                Debug.Log($"Connection state changed: {param.m_info.m_eState.ToString()} - {param.m_info.m_szEndDebug}");
+            }
+        }
 
-    private void SetConnectedComplete() => connectedComplete.SetResult(connectedComplete.Task);
-    private void OnConnectionFailed() => OnDisconnected.Invoke();
-    public void FlushData()
-    {
-      SteamNetworkingSockets.FlushMessagesOnConnection(HostConnection);
+        public void Disconnect()
+        {
+            cancelToken?.Cancel();
+            Dispose();
+
+            if (HostConnection.m_HSteamNetConnection != 0)
+            {
+                Debug.Log("Sending Disconnect message");
+                SteamNetworkingSockets.CloseConnection(HostConnection, 0, "Graceful disconnect", false);
+                HostConnection.m_HSteamNetConnection = 0;
+            }
+        }
+
+        protected void Dispose()
+        {
+            if (c_onConnectionChange != null)
+            {
+                c_onConnectionChange.Dispose();
+                c_onConnectionChange = null;
+            }
+        }
+
+        private void InternalDisconnect()
+        {
+            Connected = false;
+            OnDisconnected.Invoke();
+            Debug.Log("Disconnected.");
+            SteamNetworkingSockets.CloseConnection(HostConnection, 0, "Disconnected", false);
+        }
+
+        public void ReceiveData()
+        {
+            IntPtr[] ptrs = new IntPtr[MAX_MESSAGES];
+            int messageCount;
+
+            if ((messageCount = SteamNetworkingSockets.ReceiveMessagesOnConnection(HostConnection, ptrs, MAX_MESSAGES)) > 0)
+            {
+                for (int i = 0; i < messageCount; i++)
+                {
+                    (byte[] data, int ch) = ProcessMessage(ptrs[i]);
+                    if (Connected)
+                    {
+                        OnReceivedData(data, ch);
+                    }
+                    else
+                    {
+                        BufferedData.Add(() => OnReceivedData(data, ch));
+                    }
+                }
+            }
+        }
+
+        public void Send(byte[] data, int channelId)
+        {
+            EResult res = SendSocket(HostConnection, data, channelId);
+
+            if (res == EResult.k_EResultNoConnection || res == EResult.k_EResultInvalidParam)
+            {
+                Debug.Log($"Connection to server was lost.");
+                InternalDisconnect();
+            }
+            else if (res != EResult.k_EResultOK)
+            {
+                Debug.LogError($"Could not send: {res.ToString()}");
+            }
+        }
+
+        private void SetConnectedComplete() => connectedComplete.SetResult(connectedComplete.Task);
+        private void OnConnectionFailed() => OnDisconnected.Invoke();
+        public void FlushData()
+        {
+            SteamNetworkingSockets.FlushMessagesOnConnection(HostConnection);
+        }
     }
-  }
 }
 #endif // !DISABLESTEAMWORKS

--- a/NextCommon.cs
+++ b/NextCommon.cs
@@ -1,43 +1,50 @@
 #if !DISABLESTEAMWORKS
-using Mirror;
 using Steamworks;
 using System;
-using System.Linq;
 using System.Runtime.InteropServices;
 using UnityEngine;
 
-public abstract class NextCommon
+namespace Mirror.FizzySteam
 {
-  protected const int MAX_MESSAGES = 256;
-
-  protected EResult SendSocket(HSteamNetConnection conn, byte[] data, int channelId)
-  {
-    Array.Resize(ref data, data.Length + 1);
-    data[data.Length - 1] = (byte)channelId;
-
-    GCHandle pinnedArray = GCHandle.Alloc(data, GCHandleType.Pinned);
-    IntPtr pData = pinnedArray.AddrOfPinnedObject();
-    int sendFlag = channelId == Channels.Unreliable ? Constants.k_nSteamNetworkingSend_Unreliable : Constants.k_nSteamNetworkingSend_Reliable;
-    EResult res = SteamNetworkingSockets.SendMessageToConnection(conn, pData, (uint)data.Length, sendFlag, out long _);
-    if(res != EResult.k_EResultOK)
+    public abstract class NextCommon
     {
-      Debug.LogWarning($"Send issue: {res}");
+        protected const int MAX_MESSAGES = 256;
+
+        protected EResult SendSocket(HSteamNetConnection conn, byte[] data, int channelId)
+        {
+            Array.Resize(ref data, data.Length + 1);
+            data[data.Length - 1] = (byte)channelId;
+
+            GCHandle pinnedArray = GCHandle.Alloc(data, GCHandleType.Pinned);
+            IntPtr pData = pinnedArray.AddrOfPinnedObject();
+            int sendFlag = channelId == Channels.Unreliable ? Constants.k_nSteamNetworkingSend_Unreliable : Constants.k_nSteamNetworkingSend_Reliable;
+            EResult res = SteamNetworkingSockets.SendMessageToConnection(conn, pData, (uint)data.Length, sendFlag, out long _);
+            if (res != EResult.k_EResultOK)
+            {
+                Debug.LogWarning($"Send issue: {res}");
+            }
+
+            pinnedArray.Free();
+            return res;
+        }
+
+        protected (byte[], int) ProcessMessage(IntPtr ptrs)
+        {
+            throw new NotImplementedException("It is not possible to implament the ProcessMessage function based on the current release version of Steamworks.NET.\nWorkarounds do exist, please see the comments section in the NextCommon.cs for more information.");
+
+            //HACK: If you have choosen to implament the latest change set from Steamworks.NET as documented here: https://github.com/rlabrecque/Steamworks.NET/issues/424 then you can safely uncomment the following code
+            
+            //NOTE: Heathen's Steamworks Foundation and Steamworks Complete already has 424 implamented and so you can safely use the following code as is
+
+            //SteamNetworkingMessage_t data = Marshal.PtrToStructure<SteamNetworkingMessage_t>(ptrs);
+            //byte[] managedArray = new byte[data.m_cbSize];
+            //Marshal.Copy(data.m_pData, managedArray, 0, data.m_cbSize);
+            //SteamNetworkingMessage_t.Release(ptrs);
+
+            //int channel = managedArray[managedArray.Length - 1];
+            //Array.Resize(ref managedArray, managedArray.Length - 1);
+            //return (managedArray, channel);
+        }
     }
-
-    pinnedArray.Free();
-    return res;
-  } 
-
-  protected (byte[], int) ProcessMessage(IntPtr ptrs)
-  {
-    SteamNetworkingMessage_t data = Marshal.PtrToStructure<SteamNetworkingMessage_t>(ptrs);
-    byte[] managedArray = new byte[data.m_cbSize];    
-    Marshal.Copy(data.m_pData, managedArray, 0, data.m_cbSize);
-    NativeMethods.SteamAPI_SteamNetworkingMessage_t_Release(ptrs);
-
-    int channel = managedArray[managedArray.Length - 1];
-    Array.Resize(ref managedArray, managedArray.Length - 1);
-    return (managedArray, channel);
-  }
 }
 #endif // !DISABLESTEAMWORKS

--- a/NextServer.cs
+++ b/NextServer.cs
@@ -2,206 +2,213 @@
 using Steamworks;
 using System;
 using System.Linq;
-using System.Threading.Tasks;
 using UnityEngine;
 
 namespace Mirror.FizzySteam
 {
-  public class NextServer : NextCommon, IServer
-  {
-    private event Action<int> OnConnected;
-    private event Action<int, byte[], int> OnReceivedData;
-    private event Action<int> OnDisconnected;
-    private event Action<int, Exception> OnReceivedError;
-
-    private BidirectionalDictionary<HSteamNetConnection, int> connToMirrorID;
-    private BidirectionalDictionary<CSteamID, int> steamIDToMirrorID;
-    private int maxConnections;
-    private int nextConnectionID;
-
-    private HSteamListenSocket listenSocket;
-
-    private Callback<SteamNetConnectionStatusChangedCallback_t> c_onConnectionChange = null;
-
-    private NextServer(int maxConnections)
+    public class NextServer : NextCommon, IServer
     {
-      this.maxConnections = maxConnections;
-      connToMirrorID = new BidirectionalDictionary<HSteamNetConnection, int>();
-      steamIDToMirrorID = new BidirectionalDictionary<CSteamID, int>();
-      nextConnectionID = 1;
-      c_onConnectionChange = Callback<SteamNetConnectionStatusChangedCallback_t>.Create(OnConnectionStatusChanged);
-    }
+        private event Action<int> OnConnected;
+        private event Action<int, byte[], int> OnReceivedData;
+        private event Action<int> OnDisconnected;
+        private event Action<int, Exception> OnReceivedError;
 
-    public static NextServer CreateServer(FizzySteamworks transport, int maxConnections)
-    {
-      NextServer s = new NextServer(maxConnections);
+        private BidirectionalDictionary<HSteamNetConnection, int> connToMirrorID;
+        private BidirectionalDictionary<CSteamID, int> steamIDToMirrorID;
+        private int maxConnections;
+        private int nextConnectionID;
 
-      s.OnConnected += (id) => transport.OnServerConnected.Invoke(id);
-      s.OnDisconnected += (id) => transport.OnServerDisconnected.Invoke(id);
-      s.OnReceivedData += (id, data, ch) => transport.OnServerDataReceived.Invoke(id, new ArraySegment<byte>(data), ch);
-      s.OnReceivedError += (id, exception) => transport.OnServerError.Invoke(id, exception);
+        private HSteamListenSocket listenSocket;
 
-      if (!SteamManager.Initialized)
-      {
-        Debug.LogError("SteamWorks not initialized.");
-      }
+        private Callback<SteamNetConnectionStatusChangedCallback_t> c_onConnectionChange = null;
 
-      s.Host();
-
-      return s;
-    }
-
-    private void Host()
-    {
-      SteamNetworkingConfigValue_t[] options = new SteamNetworkingConfigValue_t[] { };
-      listenSocket = SteamNetworkingSockets.CreateListenSocketP2P(0, options.Length, options);
-    }
-
-    private void OnConnectionStatusChanged(SteamNetConnectionStatusChangedCallback_t param)
-    {
-      ulong clientSteamID = param.m_info.m_identityRemote.GetSteamID64();
-      if (param.m_info.m_eState == ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_Connecting)
-      {
-        if (connToMirrorID.Count >= maxConnections)
+        private NextServer(int maxConnections)
         {
-          Debug.Log($"Incoming connection {clientSteamID} would exceed max connection count. Rejecting.");
-          SteamNetworkingSockets.CloseConnection(param.m_hConn, 0, "Max Connection Count", false);
-          return;
+            this.maxConnections = maxConnections;
+            connToMirrorID = new BidirectionalDictionary<HSteamNetConnection, int>();
+            steamIDToMirrorID = new BidirectionalDictionary<CSteamID, int>();
+            nextConnectionID = 1;
+            c_onConnectionChange = Callback<SteamNetConnectionStatusChangedCallback_t>.Create(OnConnectionStatusChanged);
         }
 
-        EResult res;
-
-        if ((res = SteamNetworkingSockets.AcceptConnection(param.m_hConn)) == EResult.k_EResultOK)
+        public static NextServer CreateServer(FizzySteamworks transport, int maxConnections)
         {
-          Debug.Log($"Accepting connection {clientSteamID}");
-        }
-        else
-        {
-          Debug.Log($"Connection {clientSteamID} could not be accepted: {res.ToString()}");
-        }
-      }
-      else if (param.m_info.m_eState == ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_Connected)
-      {
-        int connectionId = nextConnectionID++;
-        connToMirrorID.Add(param.m_hConn, connectionId);
-        steamIDToMirrorID.Add(param.m_info.m_identityRemote.GetSteamID(), connectionId);
-        OnConnected.Invoke(connectionId);
-        Debug.Log($"Client with SteamID {clientSteamID} connected. Assigning connection id {connectionId}");
-      }
-      else if (param.m_info.m_eState == ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ClosedByPeer || param.m_info.m_eState == ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ProblemDetectedLocally)
-      {
-        if (connToMirrorID.TryGetValue(param.m_hConn, out int connId))
-        {
-          InternalDisconnect(connId, param.m_hConn);
-        }
-      }
-      else
-      {
-        Debug.Log($"Connection {clientSteamID} state changed: {param.m_info.m_eState.ToString()}");
-      }
-    }
+            NextServer s = new NextServer(maxConnections);
 
-    private void InternalDisconnect(int connId, HSteamNetConnection socket)
-    {
-      OnDisconnected.Invoke(connId);
-      SteamNetworkingSockets.CloseConnection(socket, 0, "Graceful disconnect", false);
-      connToMirrorID.Remove(connId);
-      steamIDToMirrorID.Remove(connId);
-      Debug.Log($"Client with ConnectionID {connId} disconnected.");
-    }
+            s.OnConnected += (id) => transport.OnServerConnected.Invoke(id);
+            s.OnDisconnected += (id) => transport.OnServerDisconnected.Invoke(id);
+            s.OnReceivedData += (id, data, ch) => transport.OnServerDataReceived.Invoke(id, new ArraySegment<byte>(data), ch);
+            s.OnReceivedError += (id, exception) => transport.OnServerError.Invoke(id, exception);
 
-    public void Disconnect(int connectionId)
-    {
-      if (connToMirrorID.TryGetValue(connectionId, out HSteamNetConnection conn))
-      {
-        Debug.Log($"Connection id {connectionId} disconnected.");
-        SteamNetworkingSockets.CloseConnection(conn, 0, "Disconnected by server", false);
-        steamIDToMirrorID.Remove(connectionId);
-        connToMirrorID.Remove(connectionId);
-        OnDisconnected(connectionId);
-      }
-      else
-      {
-        Debug.LogWarning("Trying to disconnect unknown connection id: " + connectionId);
-      }
-    }
-
-    public void FlushData()
-    {
-      foreach (HSteamNetConnection conn in connToMirrorID.FirstTypes)
-      {
-        SteamNetworkingSockets.FlushMessagesOnConnection(conn);
-      }
-    }
-
-    public void ReceiveData()
-    {
-      foreach (HSteamNetConnection conn in connToMirrorID.FirstTypes.ToList())
-      {
-        if (connToMirrorID.TryGetValue(conn, out int connId))
-        {
-          IntPtr[] ptrs = new IntPtr[MAX_MESSAGES];
-          int messageCount;
-
-          if ((messageCount = SteamNetworkingSockets.ReceiveMessagesOnConnection(conn, ptrs, MAX_MESSAGES)) > 0)
-          {
-            for (int i = 0; i < messageCount; i++)
+            try
             {
-              (byte[] data, int ch) = ProcessMessage(ptrs[i]);
-              OnReceivedData(connId, data, ch);
+#if UNITY_SERVER
+                SteamGameServerNetworkingUtils.InitRelayNetworkAccess();
+#else
+                SteamNetworkingUtils.InitRelayNetworkAccess();
+#endif
             }
-          }
+            catch (Exception ex)
+            {
+                Debug.LogException(ex);
+            }
+
+            s.Host();
+
+            return s;
         }
-      }
-    }
 
-    public void Send(int connectionId, byte[] data, int channelId)
-    {
-      if (connToMirrorID.TryGetValue(connectionId, out HSteamNetConnection conn))
-      {
-        EResult res = SendSocket(conn, data, channelId);
-
-        if (res == EResult.k_EResultNoConnection || res == EResult.k_EResultInvalidParam)
+        private void Host()
         {
-          Debug.Log($"Connection to {connectionId} was lost.");
-          InternalDisconnect(connectionId, conn);
+            SteamNetworkingConfigValue_t[] options = new SteamNetworkingConfigValue_t[] { };
+            listenSocket = SteamNetworkingSockets.CreateListenSocketP2P(0, options.Length, options);
         }
-        else if (res != EResult.k_EResultOK)
+
+        private void OnConnectionStatusChanged(SteamNetConnectionStatusChangedCallback_t param)
         {
-          Debug.LogError($"Could not send: {res.ToString()}");
+            ulong clientSteamID = param.m_info.m_identityRemote.GetSteamID64();
+            if (param.m_info.m_eState == ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_Connecting)
+            {
+                if (connToMirrorID.Count >= maxConnections)
+                {
+                    Debug.Log($"Incoming connection {clientSteamID} would exceed max connection count. Rejecting.");
+                    SteamNetworkingSockets.CloseConnection(param.m_hConn, 0, "Max Connection Count", false);
+                    return;
+                }
+
+                EResult res;
+
+                if ((res = SteamNetworkingSockets.AcceptConnection(param.m_hConn)) == EResult.k_EResultOK)
+                {
+                    Debug.Log($"Accepting connection {clientSteamID}");
+                }
+                else
+                {
+                    Debug.Log($"Connection {clientSteamID} could not be accepted: {res.ToString()}");
+                }
+            }
+            else if (param.m_info.m_eState == ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_Connected)
+            {
+                int connectionId = nextConnectionID++;
+                connToMirrorID.Add(param.m_hConn, connectionId);
+                steamIDToMirrorID.Add(param.m_info.m_identityRemote.GetSteamID(), connectionId);
+                OnConnected.Invoke(connectionId);
+                Debug.Log($"Client with SteamID {clientSteamID} connected. Assigning connection id {connectionId}");
+            }
+            else if (param.m_info.m_eState == ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ClosedByPeer || param.m_info.m_eState == ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ProblemDetectedLocally)
+            {
+                if (connToMirrorID.TryGetValue(param.m_hConn, out int connId))
+                {
+                    InternalDisconnect(connId, param.m_hConn);
+                }
+            }
+            else
+            {
+                Debug.Log($"Connection {clientSteamID} state changed: {param.m_info.m_eState.ToString()}");
+            }
         }
-      }
-      else
-      {
-        Debug.LogError("Trying to send on unknown connection: " + connectionId);
-        OnReceivedError.Invoke(connectionId, new Exception("ERROR Unknown Connection"));
-      }
-    }
 
-    public string ServerGetClientAddress(int connectionId)
-    {
-      if (steamIDToMirrorID.TryGetValue(connectionId, out CSteamID steamId))
-      {
-        return steamId.ToString();
-      }
-      else
-      {
-        Debug.LogError("Trying to get info on unknown connection: " + connectionId);
-        OnReceivedError.Invoke(connectionId, new Exception("ERROR Unknown Connection"));
-        return string.Empty;
-      }
-    }
+        private void InternalDisconnect(int connId, HSteamNetConnection socket)
+        {
+            OnDisconnected.Invoke(connId);
+            SteamNetworkingSockets.CloseConnection(socket, 0, "Graceful disconnect", false);
+            connToMirrorID.Remove(connId);
+            steamIDToMirrorID.Remove(connId);
+            Debug.Log($"Client with ConnectionID {connId} disconnected.");
+        }
 
-    public void Shutdown()
-    {
-      SteamNetworkingSockets.CloseListenSocket(listenSocket);
+        public void Disconnect(int connectionId)
+        {
+            if (connToMirrorID.TryGetValue(connectionId, out HSteamNetConnection conn))
+            {
+                Debug.Log($"Connection id {connectionId} disconnected.");
+                SteamNetworkingSockets.CloseConnection(conn, 0, "Disconnected by server", false);
+                steamIDToMirrorID.Remove(connectionId);
+                connToMirrorID.Remove(connectionId);
+                OnDisconnected(connectionId);
+            }
+            else
+            {
+                Debug.LogWarning("Trying to disconnect unknown connection id: " + connectionId);
+            }
+        }
 
-      if (c_onConnectionChange != null)
-      {
-        c_onConnectionChange.Dispose();
-        c_onConnectionChange = null;
-      }
+        public void FlushData()
+        {
+            foreach (HSteamNetConnection conn in connToMirrorID.FirstTypes)
+            {
+                SteamNetworkingSockets.FlushMessagesOnConnection(conn);
+            }
+        }
+
+        public void ReceiveData()
+        {
+            foreach (HSteamNetConnection conn in connToMirrorID.FirstTypes.ToList())
+            {
+                if (connToMirrorID.TryGetValue(conn, out int connId))
+                {
+                    IntPtr[] ptrs = new IntPtr[MAX_MESSAGES];
+                    int messageCount;
+
+                    if ((messageCount = SteamNetworkingSockets.ReceiveMessagesOnConnection(conn, ptrs, MAX_MESSAGES)) > 0)
+                    {
+                        for (int i = 0; i < messageCount; i++)
+                        {
+                            (byte[] data, int ch) = ProcessMessage(ptrs[i]);
+                            OnReceivedData(connId, data, ch);
+                        }
+                    }
+                }
+            }
+        }
+
+        public void Send(int connectionId, byte[] data, int channelId)
+        {
+            if (connToMirrorID.TryGetValue(connectionId, out HSteamNetConnection conn))
+            {
+                EResult res = SendSocket(conn, data, channelId);
+
+                if (res == EResult.k_EResultNoConnection || res == EResult.k_EResultInvalidParam)
+                {
+                    Debug.Log($"Connection to {connectionId} was lost.");
+                    InternalDisconnect(connectionId, conn);
+                }
+                else if (res != EResult.k_EResultOK)
+                {
+                    Debug.LogError($"Could not send: {res.ToString()}");
+                }
+            }
+            else
+            {
+                Debug.LogError("Trying to send on unknown connection: " + connectionId);
+                OnReceivedError.Invoke(connectionId, new Exception("ERROR Unknown Connection"));
+            }
+        }
+
+        public string ServerGetClientAddress(int connectionId)
+        {
+            if (steamIDToMirrorID.TryGetValue(connectionId, out CSteamID steamId))
+            {
+                return steamId.ToString();
+            }
+            else
+            {
+                Debug.LogError("Trying to get info on unknown connection: " + connectionId);
+                OnReceivedError.Invoke(connectionId, new Exception("ERROR Unknown Connection"));
+                return string.Empty;
+            }
+        }
+
+        public void Shutdown()
+        {
+            SteamNetworkingSockets.CloseListenSocket(listenSocket);
+
+            if (c_onConnectionChange != null)
+            {
+                c_onConnectionChange.Dispose();
+                c_onConnectionChange = null;
+            }
+        }
     }
-  }
 }
 #endif // !DISABLESTEAMWORKS

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This is a community maintained repo forked from **[RayStorm](https://github.com/
 
 Mirror **[docs](https://mirror-networking.com/docs/Transports/Fizzy.html)** and the official community **[Discord](https://discord.gg/N9QVxbM)**.
 
-FizzySteamworks brings together **[Steam](https://store.steampowered.com)** and **[Mirror](https://github.com/vis2k/Mirror)** . It supports both the old SteamNetworking and the new SteamSockets. **NOTE Steamworks.NET has a known issue preventing the use of the new SteamSockets and can only be used if you have implamented Steamworks.NET change set 424 or are using Heathen's Steamworks; if either case is true you will need to uncomment code located in the NextServer.cs**
+FizzySteamworks brings together **[Steam](https://store.steampowered.com)** and **[Mirror](https://github.com/vis2k/Mirror)** . It supports both the old SteamNetworking and the new SteamSockets. 
+
+**NOTE Steamworks.NET has a known issue preventing the use of the new SteamSockets and can only be used if you have implamented Steamworks.NET change set 424 or are using Heathen's Steamworks; if either case is true you will need to uncomment code located in the NextCommon.cs in the ProcessMessage method for the Steam Sockets integration to work**
 
 ## Dependencies
 If you are using Heathen's Steamworks Foundation or Steamworks Complete you do not need to install Steamworks.NET as they already have it included.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a community maintained repo forked from **[RayStorm](https://github.com/
 
 Mirror **[docs](https://mirror-networking.com/docs/Transports/Fizzy.html)** and the official community **[Discord](https://discord.gg/N9QVxbM)**.
 
-FizzySteamworks brings together **[Steam](https://store.steampowered.com)** and **[Mirror](https://github.com/vis2k/Mirror)** . It supports both the old SteamNetworking and the new SteamSockets.
+FizzySteamworks brings together **[Steam](https://store.steampowered.com)** and **[Mirror](https://github.com/vis2k/Mirror)** . It supports both the old SteamNetworking and the new SteamSockets. **NOTE Steamworks.NET has a known issue preventing the use of the new SteamSockets and can only be used if you have implamented Steamworks.NET change set 424 or are using Heathen's Steamworks; if either case is true you will need to uncomment code located in the NextServer.cs**
 
 ## Dependencies
 If you are using Heathen's Steamworks Foundation or Steamworks Complete you do not need to install Steamworks.NET as they already have it included.

--- a/README.md
+++ b/README.md
@@ -7,34 +7,35 @@ Mirror **[docs](https://mirror-networking.com/docs/Transports/Fizzy.html)** and 
 FizzySteamworks brings together **[Steam](https://store.steampowered.com)** and **[Mirror](https://github.com/vis2k/Mirror)** . It supports both the old SteamNetworking and the new SteamSockets.
 
 ## Dependencies
-If you want an easy import, skip the steps below & download the latest **[unitypackage](https://github.com/Chykary/FizzySteamworks/releases)**, **it has SteamWorks.Net already included**.
+If you are using Heathen's Steamworks Foundation or Steamworks Complete you do not need to install Steamworks.NET as they already have it included.
 
-**Note: If you already have SteamWorks.Net in your project, you might need to delete either your import or the one included in the FizzySteamworks [unitypackage](https://github.com/Chykary/FizzySteamworks/releases).**
+You must have Mirror installed and working before you can use this transport.
+**[Mirror](https://github.com/vis2k/Mirror)** FizzySteamworks is also obviously dependant on Mirror which is a streamline, bug fixed, maintained version of UNET for Unity.
 
-Both of these projects need to be installed and working before you can use this transport.
-1. **[SteamWorks.NET](https://github.com/rlabrecque/Steamworks.NET)** FizzySteamworks relies on Steamworks.NET to communicate with the **[Steamworks API](https://partner.steamgames.com/doc/sdk)**. **Requires .Net 4.x**  
-2. **[Mirror](https://github.com/vis2k/Mirror)** FizzySteamworks is also obviously dependant on Mirror which is a streamline, bug fixed, maintained version of UNET for Unity.
+You must also have installed and working either
+**[Steamworks.NET](https://github.com/rlabrecque/Steamworks.NET)** FizzySteamworks relies on Steamworks.NET to communicate with the **[Steamworks API](https://partner.steamgames.com/doc/sdk)**. **Requires .Net 4.x**  
+
+or
+
+**[Heathen's free Steamworks Foundation](https://assetstore.unity.com/packages/tools/integration/steamworks-v2-foundation-186949) or [Heathen's premimum Steamworks Complete](https://assetstore.unity.com/packages/tools/integration/steamworks-v2-complete-190316)**
+**NOTE: Heathen's Steamworks is built on and includes Steamworks.NET so if you already have that installed you must fully remove it first**
 
 ## Setting Up
 
 1. Install Mirror **(Requires Mirror 35.0+)** from the Unity asset store **[Download Mirror](https://assetstore.unity.com/packages/tools/network/mirror-129321)**.
 2. Install FizzySteamworks **[unitypackage](https://github.com/Chykary/FizzySteamworks/releases)** from the release section.
 3. In your **"NetworkManager"** object replace **"Telepathy"** script with **"FizzySteamworks"** script.
-4. Enter your Steam App ID in the **"FizzySteamworks"** script.
-
-**Note: The  default 480(Spacewar) appid is a very grey area, technically, it's not allowed but they don't really do anything about it. When you have your own appid from steam then replace the 480 with your own game appid.
-If you know a better way around this please make a [Issue ticket.](https://github.com/Chykary/FizzySteamworks/issues)**
 
 ## Host
-To be able to have your game working you need to make sure you have Steam running in the background. **SteamManager will print a Debug Message if it initializes correctly.**
+To be able to have your game working you need to make sure you have Steam running in the background and that the Steam API initalized correctly. You can then call StartHost and use Mirror as you normally would.
 
 ## Client
-Before sending your game to your buddy make sure you have your **steamID64** ready. To find your **steamID64** the transport prints the hosts **steamID64** in the console when the server has started.
+To connect a client to a host or server you need the CSteamID of the target you wish to connect to this is used in place of IP/Port. If your creating a Peer to Peer architecture then you would use the CSteamID of the host, this is Steam user ID as a ulong value. If you are creating a Client Server architecture then you will be using the CSteamID issued to the Steam Game Server when it logs the Steam API on. This is an advanced use case supported by Heathen's Steamworks but requires additional custom code if your using Steamworks.NET directly.
 
-1. Send the game to your buddy. The transport shows your Steam User ID after you have started a server.
-2. Your buddy needs your **steamID64** to be able to connect.
+1. Send the game to your buddy.
+2. Your buddy needs the host or game server **steamID64** to be able to connect.
 3. Place the **steamID64** into **"localhost"** then click **"Client"**
-5. Then they will be connected to you.
+5. Then they will be connected to your server be that your machine as a P2P connection or yoru Steam Game Server as a Client Server connection.
 
 ## Testing your game locally
-You cant connect to yourself locally while using **FizzySteamworks** since it's using steams P2P. If you want to test your game locally you'll have to use **"Telepathy Transport"** instead of **"FizzySteamworks"**.
+You cant connect to yourself locally while using **FizzySteamworks** since it's using Steams Networking which runs over Steam Client and addresses its connection based on the unique CSteamID of each actor. If you want to test your game locally you'll have to use **"Telepathy Transport"** instead of **"FizzySteamworks"**.


### PR DESCRIPTION
This change will allow this transport to support both P2P and Client Server, it will enable it to work with release Steamworks.NET, Heathen Steamworks and any 3rd party built on the original Steamworks.NET

See full notes below.


** VERY IMPORTANT **
Do not include Steamworks.NET in your build, that will cause issues when they use teh actual release Steamworks.NET as your modification is not inline with theres. It also means they cant use there own variations of the manager or any other 3rd party such as Heathen's Steamworks

- Removed FizzySteamworks.Awake
This was creating a steam_appid.txt if it was missing and that is a huge issue, that file should not be there in release so that was a major flaw. it also modified the app ID so if you typed in a different value here than you had in your steam_appid in your Editor and or you where using Heathen's Steamworks you would cause an issue where the user thought they where initalizing as 1 app but where actually running as another.

- Removed FetchSteamID
This would only work on clients and serves no real funciton other than initalizing relay which now has its own method and is platform sinsative.

- Added InitRelayNetworkAccess
This only funcitons in the case that UseNextGenSteamNetworking is true, it is platform sinsative e.g. uses GameServer API where needed

- Removed all uses of SteamManager.XXXX
SteamManager is an example class and has many many issues. It was only used to check for initalization of the API however every Steam API call already does this via TestIfAvailableClient and TestIfAvailableGameServer as required so we can simply remove all the if(SteamManager.Initalized) and instead use classic Try/Catch ... this also means this new version will work with Steamworks.NET SteamManager and Heathen's SteamSettings as well as any custom manager a user might create

- Removed unnessisary using statements

- Wrapped all API calls with platform check
#if UNITY_SERVER
	// Server only API calls
#else
	// Client only API calls
#endif

- NextCommon.ProcessMessage(IntPrt ptrs)
This has been made NotImplemented as it is not possible to support with the current release version of Steamworks.NET. If the user has implamented Steamworks.NET change set 424 then your previous code would throw an error. I have provided commented out code that will work with 424 so the user can choose to implament this if they follow the linked change set and or are using Heathen's Steamworks Foundation or Steamworks Complete which already has 424 implamented.
This is a temporary measure until Steamworks.NET releases an offical fix for the release issue which is in testing now

- Updated the README
Updated the notes on how to install
Removed the note about 480 ... 480 is the test app you are supposed to use it for testing its not that it isn't allowed
Updated the connection notes to support both P2P and Client Server
Added links to Heathen's Steamworks Foundation (free) and Steamworks Complete as both would now be supported by this transport as well as Steamworks.NET