### PR TITLE
Server Build fix

### DIFF
--- a/com.mirror.steamworks.net/NextCommon.cs
+++ b/com.mirror.steamworks.net/NextCommon.cs
@@ -18,7 +18,7 @@ namespace Mirror.FizzySteam
             GCHandle pinnedArray = GCHandle.Alloc(data, GCHandleType.Pinned);
             IntPtr pData = pinnedArray.AddrOfPinnedObject();
             int sendFlag = channelId == Channels.Unreliable ? Constants.k_nSteamNetworkingSend_Unreliable : Constants.k_nSteamNetworkingSend_Reliable;
-#if UNITY_SERVER || true
+#if UNITY_SERVER
             EResult res = SteamGameServerNetworkingSockets.SendMessageToConnection(conn, pData, (uint)data.Length, sendFlag, out long _);
 #else
             EResult res = SteamNetworkingSockets.SendMessageToConnection(conn, pData, (uint)data.Length, sendFlag, out long _);

--- a/com.mirror.steamworks.net/NextCommon.cs
+++ b/com.mirror.steamworks.net/NextCommon.cs
@@ -18,7 +18,11 @@ namespace Mirror.FizzySteam
             GCHandle pinnedArray = GCHandle.Alloc(data, GCHandleType.Pinned);
             IntPtr pData = pinnedArray.AddrOfPinnedObject();
             int sendFlag = channelId == Channels.Unreliable ? Constants.k_nSteamNetworkingSend_Unreliable : Constants.k_nSteamNetworkingSend_Reliable;
+#if UNITY_SERVER || true
+            EResult res = SteamGameServerNetworkingSockets.SendMessageToConnection(conn, pData, (uint)data.Length, sendFlag, out long _);
+#else
             EResult res = SteamNetworkingSockets.SendMessageToConnection(conn, pData, (uint)data.Length, sendFlag, out long _);
+#endif
             if (res != EResult.k_EResultOK)
             {
                 Debug.LogWarning($"Send issue: {res}");

--- a/com.mirror.steamworks.net/NextServer.cs
+++ b/com.mirror.steamworks.net/NextServer.cs
@@ -61,7 +61,11 @@ namespace Mirror.FizzySteam
         private void Host()
         {
             SteamNetworkingConfigValue_t[] options = new SteamNetworkingConfigValue_t[] { };
+#if UNITY_SERVER
+            listenSocket = SteamGameServerNetworkingSockets.CreateListenSocketP2P(0, options.Length, options);
+#else
             listenSocket = SteamNetworkingSockets.CreateListenSocketP2P(0, options.Length, options);
+#endif
         }
 
         private void OnConnectionStatusChanged(SteamNetConnectionStatusChangedCallback_t param)
@@ -72,13 +76,21 @@ namespace Mirror.FizzySteam
                 if (connToMirrorID.Count >= maxConnections)
                 {
                     Debug.Log($"Incoming connection {clientSteamID} would exceed max connection count. Rejecting.");
+#if UNITY_SERVER
+                    SteamGameServerNetworkingSockets.CloseConnection(param.m_hConn, 0, "Max Connection Count", false);
+#else
                     SteamNetworkingSockets.CloseConnection(param.m_hConn, 0, "Max Connection Count", false);
+#endif
                     return;
                 }
 
                 EResult res;
 
+#if UNITY_SERVER
+                if ((res = SteamGameServerNetworkingSockets.AcceptConnection(param.m_hConn)) == EResult.k_EResultOK)
+#else
                 if ((res = SteamNetworkingSockets.AcceptConnection(param.m_hConn)) == EResult.k_EResultOK)
+#endif
                 {
                     Debug.Log($"Accepting connection {clientSteamID}");
                 }
@@ -111,7 +123,11 @@ namespace Mirror.FizzySteam
         private void InternalDisconnect(int connId, HSteamNetConnection socket)
         {
             OnDisconnected.Invoke(connId);
+#if UNITY_SERVER
+            SteamGameServerNetworkingSockets.CloseConnection(socket, 0, "Graceful disconnect", false);
+#else
             SteamNetworkingSockets.CloseConnection(socket, 0, "Graceful disconnect", false);
+#endif
             connToMirrorID.Remove(connId);
             steamIDToMirrorID.Remove(connId);
             Debug.Log($"Client with ConnectionID {connId} disconnected.");
@@ -122,7 +138,11 @@ namespace Mirror.FizzySteam
             if (connToMirrorID.TryGetValue(connectionId, out HSteamNetConnection conn))
             {
                 Debug.Log($"Connection id {connectionId} disconnected.");
+#if UNITY_SERVER
+                SteamGameServerNetworkingSockets.CloseConnection(conn, 0, "Disconnected by server", false);
+#else
                 SteamNetworkingSockets.CloseConnection(conn, 0, "Disconnected by server", false);
+#endif
                 steamIDToMirrorID.Remove(connectionId);
                 connToMirrorID.Remove(connectionId);
                 OnDisconnected(connectionId);
@@ -137,7 +157,11 @@ namespace Mirror.FizzySteam
         {
             foreach (HSteamNetConnection conn in connToMirrorID.FirstTypes)
             {
+#if UNITY_SERVER
+                SteamGameServerNetworkingSockets.FlushMessagesOnConnection(conn);
+#else
                 SteamNetworkingSockets.FlushMessagesOnConnection(conn);
+#endif
             }
         }
 
@@ -150,7 +174,11 @@ namespace Mirror.FizzySteam
                     IntPtr[] ptrs = new IntPtr[MAX_MESSAGES];
                     int messageCount;
 
+#if UNITY_SERVER
+                    if ((messageCount = SteamGameServerNetworkingSockets.ReceiveMessagesOnConnection(conn, ptrs, MAX_MESSAGES)) > 0)
+#else
                     if ((messageCount = SteamNetworkingSockets.ReceiveMessagesOnConnection(conn, ptrs, MAX_MESSAGES)) > 0)
+#endif
                     {
                         for (int i = 0; i < messageCount; i++)
                         {
@@ -201,7 +229,11 @@ namespace Mirror.FizzySteam
 
         public void Shutdown()
         {
+#if UNITY_SERVER || true
+            SteamGameServerNetworkingSockets.CloseListenSocket(listenSocket);
+#else
             SteamNetworkingSockets.CloseListenSocket(listenSocket);
+#endif
 
             if (c_onConnectionChange != null)
             {

--- a/com.mirror.steamworks.net/NextServer.cs
+++ b/com.mirror.steamworks.net/NextServer.cs
@@ -229,7 +229,7 @@ namespace Mirror.FizzySteam
 
         public void Shutdown()
         {
-#if UNITY_SERVER || true
+#if UNITY_SERVER
             SteamGameServerNetworkingSockets.CloseListenSocket(listenSocket);
 #else
             SteamNetworkingSockets.CloseListenSocket(listenSocket);

--- a/com.mirror.steamworks.net/package.json
+++ b/com.mirror.steamworks.net/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.mirror.steamworks.net",
   "displayName": "FizzySteamworks",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "unity": "2019.4",
   "author": {
     "name": "Mirror Community",


### PR DESCRIPTION
Corrected a number of points in the "NextServer" and "NextCommon" objects that could end up calling client API end points in a server build.

Also iterated the version in the package manager manifest