### PR TITLE
Fix OnConnectionStatusChanged not being called on server builds

### DIFF
--- a/com.mirror.steamworks.net/NextServer.cs
+++ b/com.mirror.steamworks.net/NextServer.cs
@@ -29,7 +29,11 @@ namespace Mirror.FizzySteam
             connToMirrorID = new BidirectionalDictionary<HSteamNetConnection, int>();
             steamIDToMirrorID = new BidirectionalDictionary<CSteamID, int>();
             nextConnectionID = 1;
+#if UNITY_SERVER
+            c_onConnectionChange = Callback<SteamNetConnectionStatusChangedCallback_t>.CreateGameServer(OnConnectionStatusChanged);
+#else
             c_onConnectionChange = Callback<SteamNetConnectionStatusChangedCallback_t>.Create(OnConnectionStatusChanged);
+#endif
         }
 
         public static NextServer CreateServer(FizzySteamworks transport, int maxConnections)


### PR DESCRIPTION
I encountered an issue where `OnConnectionStatusChanged` was not being called on a server build, which in turn caused incoming connections to not be accepted and time out.

It seems the reason for this is that server callbacks need to be registered with `CreateGameServer` instead of `Create`.

Once this change was made, OnConnectionStatusChanged is called properly, and the server can accept incoming connections.