### PR TITLE
Runtime memory allocation optimizations

### DIFF
--- a/com.mirror.steamworks.net/FizzySteamworks.cs
+++ b/com.mirror.steamworks.net/FizzySteamworks.cs
@@ -1,6 +1,6 @@
 #if !DISABLESTEAMWORKS
-using Steamworks;
 using System;
+using Steamworks;
 using UnityEngine;
 
 namespace Mirror.FizzySteam
@@ -117,9 +117,7 @@ namespace Mirror.FizzySteam
 
         public override void ClientSend(ArraySegment<byte> segment, int channelId)
         {
-            byte[] data = new byte[segment.Count];
-            Array.Copy(segment.Array, segment.Offset, data, 0, segment.Count);
-            client.Send(data, channelId);
+            client.Send(segment, channelId);
         }
 
         public override void ClientDisconnect()
@@ -202,9 +200,7 @@ namespace Mirror.FizzySteam
         {
             if (ServerActive())
             {
-                byte[] data = new byte[segment.Count];
-                Array.Copy(segment.Array, segment.Offset, data, 0, segment.Count);
-                server.Send(connectionId, data, channelId);
+                server.Send(connectionId, segment, channelId);
             }
         }
         public override void ServerDisconnect(int connectionId)

--- a/com.mirror.steamworks.net/IClient.cs
+++ b/com.mirror.steamworks.net/IClient.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mirror.FizzySteam
 {
     public interface IClient
@@ -9,6 +11,6 @@ namespace Mirror.FizzySteam
         void ReceiveData();
         void Disconnect();
         void FlushData();
-        void Send(byte[] data, int channelId);
+        void Send(ArraySegment<byte> segment, int channelId);
     }
 }

--- a/com.mirror.steamworks.net/IServer.cs
+++ b/com.mirror.steamworks.net/IServer.cs
@@ -1,9 +1,11 @@
+using System;
+
 namespace Mirror.FizzySteam
 {
     public interface IServer
     {
         void ReceiveData();
-        void Send(int connectionId, byte[] data, int channelId);
+        void Send(int connectionId, ArraySegment<byte> segment, int channelId);
         void Disconnect(int connectionId);
         void FlushData();
         string ServerGetClientAddress(int connectionId);

--- a/com.mirror.steamworks.net/LegacyClient.cs
+++ b/com.mirror.steamworks.net/LegacyClient.cs
@@ -1,8 +1,8 @@
 ﻿#if !DISABLESTEAMWORKS
-using Steamworks;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Steamworks;
 using UnityEngine;
 
 namespace Mirror.FizzySteam
@@ -45,13 +45,13 @@ namespace Mirror.FizzySteam
 #endif
                 c.Connect(host);
             }
-            catch(FormatException)
+            catch (FormatException)
             {
                 Debug.LogError($"Connection string was not in the right format. Did you enter a SteamId?");
                 c.Error = true;
                 c.OnConnectionFailed(CSteamID.Nil);
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Debug.LogError($"Unexpected exception: {ex.Message}");
                 c.Error = true;
@@ -176,7 +176,12 @@ namespace Mirror.FizzySteam
             }
         }
 
-        public void Send(byte[] data, int channelId) => Send(hostSteamID, data, channelId);
+        public void Send(ArraySegment<byte> segment, int channelId)
+        {
+            byte[] data = new byte[segment.Count];
+            Array.Copy(segment.Array, segment.Offset, data, 0, segment.Count);
+            Send(hostSteamID, data, channelId);
+        }
 
         protected override void OnConnectionFailed(CSteamID remoteId) => OnDisconnected.Invoke();
         public void FlushData() { }

--- a/com.mirror.steamworks.net/LegacyServer.cs
+++ b/com.mirror.steamworks.net/LegacyServer.cs
@@ -1,14 +1,14 @@
 ﻿#if !DISABLESTEAMWORKS
-using Steamworks;
 using System;
 using System.Collections.Generic;
+using Steamworks;
 using UnityEngine;
 
 namespace Mirror.FizzySteam
 {
     public class LegacyServer : LegacyCommon, IServer
     {
-        private event Action<int,String> OnConnectedWithAddress;
+        private event Action<int, String> OnConnectedWithAddress;
         private event Action<int, byte[], int> OnReceivedData;
         private event Action<int> OnDisconnected;
         private event Action<int, TransportError, string> OnReceivedError;
@@ -22,8 +22,8 @@ namespace Mirror.FizzySteam
         public static LegacyServer CreateServer(FizzySteamworks transport, int maxConnections)
         {
             server = new LegacyServer(transport, maxConnections);
-            
-            server.OnConnectedWithAddress += (id,addres) => transport.OnServerConnectedWithAddress.Invoke(id,addres);
+
+            server.OnConnectedWithAddress += (id, addres) => transport.OnServerConnectedWithAddress.Invoke(id, addres);
             server.OnDisconnected += (id) => transport.OnServerDisconnected.Invoke(id);
             server.OnReceivedData += (id, data, channel) => transport.OnServerDataReceived.Invoke(id, new ArraySegment<byte>(data), channel);
             server.OnReceivedError += (id, error, reason) => transport.OnServerError.Invoke(id, error, reason);
@@ -83,7 +83,7 @@ namespace Mirror.FizzySteam
 
                     int connectionId = nextConnectionID++;
                     steamToMirrorIds.Add(clientSteamID, connectionId);
-                    OnConnectedWithAddress.Invoke(connectionId,server.ServerGetClientAddress(connectionId));
+                    OnConnectedWithAddress.Invoke(connectionId, server.ServerGetClientAddress(connectionId));
                     Debug.Log($"Client with SteamID {clientSteamID} connected. Assigning connection id {connectionId}");
                     break;
                 case InternalMessages.DISCONNECT:
@@ -148,10 +148,12 @@ namespace Mirror.FizzySteam
             Dispose();
         }
 
-        public void Send(int connectionId, byte[] data, int channelId)
+        public void Send(int connectionId, ArraySegment<byte> segment, int channelId)
         {
             if (steamToMirrorIds.TryGetValue(connectionId, out CSteamID steamId))
             {
+                byte[] data = new byte[segment.Count];
+                Array.Copy(segment.Array, segment.Offset, data, 0, segment.Count);
                 Send(steamId, data, channelId);
             }
             else

--- a/com.mirror.steamworks.net/NextClient.cs
+++ b/com.mirror.steamworks.net/NextClient.cs
@@ -1,9 +1,9 @@
 #if !DISABLESTEAMWORKS
-using Steamworks;
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Steamworks;
 using UnityEngine;
 
 namespace Mirror.FizzySteam
@@ -212,11 +212,11 @@ namespace Mirror.FizzySteam
             }
         }
 
-        public void Send(byte[] data, int channelId)
+        public void Send(ArraySegment<byte> segment, int channelId)
         {
             try
             {
-                EResult res = SendSocket(HostConnection, data, channelId);
+                EResult res = SendSocket(HostConnection, segment, channelId);
 
                 if (res == EResult.k_EResultNoConnection || res == EResult.k_EResultInvalidParam)
                 {

--- a/com.mirror.steamworks.net/NextClient.cs
+++ b/com.mirror.steamworks.net/NextClient.cs
@@ -214,7 +214,12 @@ namespace Mirror.FizzySteam
                     }
                     else
                     {
-                        BufferedData.Add(() => OnReceivedData(segment, channelId));
+                        // Need to allocate new memory for these recieved messages because the main buffer will be overwritten by the buffered data is processed
+                        byte[] segmentCopy = new byte[segment.Count];
+                        Array.Copy(segment.Array, segment.Offset, segmentCopy, 0, segment.Count);
+                        int channelIdCopy = channelId;
+
+                        BufferedData.Add(() => OnReceivedData(segmentCopy, channelIdCopy));
                     }
                 }
             }

--- a/com.mirror.steamworks.net/NextClient.cs
+++ b/com.mirror.steamworks.net/NextClient.cs
@@ -15,7 +15,7 @@ namespace Mirror.FizzySteam
 
         private TimeSpan ConnectionTimeout;
 
-        private event Action<byte[], int> OnReceivedData;
+        private event Action<ArraySegment<byte>, int> OnReceivedData;
         private event Action OnConnected;
         private event Action OnDisconnected;
         private Callback<SteamNetConnectionStatusChangedCallback_t> c_onConnectionChange = null;
@@ -40,7 +40,7 @@ namespace Mirror.FizzySteam
 
             c.OnConnected += () => transport.OnClientConnected.Invoke();
             c.OnDisconnected += () => transport.OnClientDisconnected.Invoke();
-            c.OnReceivedData += (data, ch) => transport.OnClientDataReceived.Invoke(new ArraySegment<byte>(data), ch);
+            c.OnReceivedData += (segment, channelId) => transport.OnClientDataReceived.Invoke(segment, channelId);
 
             try
             {
@@ -207,14 +207,14 @@ namespace Mirror.FizzySteam
             {
                 for (int i = 0; i < messageCount; i++)
                 {
-                    (byte[] data, int ch) = ProcessMessage(messagePtrs[i]);
+                    (var segment, int channelId) = ProcessMessage(messagePtrs[i]);
                     if (Connected)
                     {
-                        OnReceivedData(data, ch);
+                        OnReceivedData(segment, channelId);
                     }
                     else
                     {
-                        BufferedData.Add(() => OnReceivedData(data, ch));
+                        BufferedData.Add(() => OnReceivedData(segment, channelId));
                     }
                 }
             }

--- a/com.mirror.steamworks.net/NextClient.cs
+++ b/com.mirror.steamworks.net/NextClient.cs
@@ -173,13 +173,15 @@ namespace Mirror.FizzySteam
             }
         }
 
-        protected void Dispose()
+        public override void Dispose()
         {
             if (c_onConnectionChange != null)
             {
                 c_onConnectionChange.Dispose();
                 c_onConnectionChange = null;
             }
+
+            base.Dispose();
         }
 
         private void InternalDisconnect()

--- a/com.mirror.steamworks.net/NextCommon.cs
+++ b/com.mirror.steamworks.net/NextCommon.cs
@@ -6,32 +6,51 @@ using UnityEngine;
 
 namespace Mirror.FizzySteam
 {
-    public abstract class NextCommon
+    public abstract class NextCommon : IDisposable
     {
+        private const int MAX_PACKET_SIZE = Constants.k_cbMaxSteamNetworkingSocketsMessageSizeSend;
+
         protected const int MAX_MESSAGES = 256;
+
+        private readonly byte[] buffer;
+        private readonly GCHandle pinnedBuffer;
+        private readonly IntPtr bufferPtr;
+
+        private bool disposed = false;
+
+        public NextCommon()
+        {
+            buffer = new byte[MAX_PACKET_SIZE];
+            pinnedBuffer = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+            bufferPtr = pinnedBuffer.AddrOfPinnedObject();
+        }
 
         protected EResult SendSocket(HSteamNetConnection conn, ArraySegment<byte> segment, int channelId)
         {
-            byte[] data = new byte[segment.Count];
-            Array.Copy(segment.Array, segment.Offset, data, 0, segment.Count);
+            int packetSize = segment.Count + 1;
 
-            Array.Resize(ref data, data.Length + 1);
-            data[data.Length - 1] = (byte)channelId;
+            if (packetSize > MAX_PACKET_SIZE)
+            {
+                Debug.LogError($"Attempted to send oversize packet with {segment.Count} bytes on channel with ID {channelId}.");
+                return EResult.k_EResultFail;
+            }
 
-            GCHandle pinnedArray = GCHandle.Alloc(data, GCHandleType.Pinned);
-            IntPtr pData = pinnedArray.AddrOfPinnedObject();
+            Array.Copy(segment.Array, segment.Offset, buffer, 0, segment.Count);
+            buffer[segment.Count] = (byte)channelId;
+
             int sendFlag = channelId == Channels.Unreliable ? Constants.k_nSteamNetworkingSend_Unreliable : Constants.k_nSteamNetworkingSend_Reliable;
+
 #if UNITY_SERVER
             EResult res = SteamGameServerNetworkingSockets.SendMessageToConnection(conn, pData, (uint)data.Length, sendFlag, out long _);
 #else
-            EResult res = SteamNetworkingSockets.SendMessageToConnection(conn, pData, (uint)data.Length, sendFlag, out long _);
+            EResult res = SteamNetworkingSockets.SendMessageToConnection(conn, bufferPtr, (uint)packetSize, sendFlag, out long _);
 #endif
+
             if (res != EResult.k_EResultOK)
             {
                 Debug.LogWarning($"Send issue: {res}");
             }
 
-            pinnedArray.Free();
             return res;
         }
 
@@ -40,11 +59,23 @@ namespace Mirror.FizzySteam
             SteamNetworkingMessage_t data = Marshal.PtrToStructure<SteamNetworkingMessage_t>(ptrs);
             byte[] managedArray = new byte[data.m_cbSize];
             Marshal.Copy(data.m_pData, managedArray, 0, data.m_cbSize);
+
             SteamNetworkingMessage_t.Release(ptrs);
 
             int channel = managedArray[managedArray.Length - 1];
             Array.Resize(ref managedArray, managedArray.Length - 1);
             return (managedArray, channel);
+        }
+
+        public virtual void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            pinnedBuffer.Free();
+            disposed = true;
         }
     }
 }

--- a/com.mirror.steamworks.net/NextCommon.cs
+++ b/com.mirror.steamworks.net/NextCommon.cs
@@ -1,7 +1,7 @@
 #if !DISABLESTEAMWORKS
-using Steamworks;
 using System;
 using System.Runtime.InteropServices;
+using Steamworks;
 using UnityEngine;
 
 namespace Mirror.FizzySteam
@@ -10,8 +10,11 @@ namespace Mirror.FizzySteam
     {
         protected const int MAX_MESSAGES = 256;
 
-        protected EResult SendSocket(HSteamNetConnection conn, byte[] data, int channelId)
+        protected EResult SendSocket(HSteamNetConnection conn, ArraySegment<byte> segment, int channelId)
         {
+            byte[] data = new byte[segment.Count];
+            Array.Copy(segment.Array, segment.Offset, data, 0, segment.Count);
+
             Array.Resize(ref data, data.Length + 1);
             data[data.Length - 1] = (byte)channelId;
 

--- a/com.mirror.steamworks.net/NextServer.cs
+++ b/com.mirror.steamworks.net/NextServer.cs
@@ -9,7 +9,7 @@ namespace Mirror.FizzySteam
     public class NextServer : NextCommon, IServer
     {
         private event Action<int, string> OnConnectedWithAddress;
-        private event Action<int, byte[], int> OnReceivedData;
+        private event Action<int, ArraySegment<byte>, int> OnReceivedData;
         private event Action<int> OnDisconnected;
         private event Action<int, TransportError, string> OnReceivedError;
 
@@ -44,7 +44,7 @@ namespace Mirror.FizzySteam
 
             server.OnConnectedWithAddress += (id, addres) => transport.OnServerConnectedWithAddress.Invoke(id, addres);
             server.OnDisconnected += (id) => transport.OnServerDisconnected.Invoke(id);
-            server.OnReceivedData += (id, data, ch) => transport.OnServerDataReceived.Invoke(id, new ArraySegment<byte>(data), ch);
+            server.OnReceivedData += (id, segment, channelId) => transport.OnServerDataReceived.Invoke(id, segment, channelId);
             server.OnReceivedError += (id, error, reason) => transport.OnServerError.Invoke(id, error, reason);
 
             try
@@ -193,8 +193,8 @@ namespace Mirror.FizzySteam
                     {
                         for (int i = 0; i < messageCount; i++)
                         {
-                            (byte[] data, int ch) = ProcessMessage(messagePtrs[i]);
-                            OnReceivedData?.Invoke(connId, data, ch);
+                            (var segment, int channelId) = ProcessMessage(messagePtrs[i]);
+                            OnReceivedData?.Invoke(connId, segment, channelId);
                         }
                     }
                 }

--- a/com.mirror.steamworks.net/NextServer.cs
+++ b/com.mirror.steamworks.net/NextServer.cs
@@ -242,6 +242,13 @@ namespace Mirror.FizzySteam
 
             c_onConnectionChange?.Dispose();
             c_onConnectionChange = null;
+
+            Dispose();
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
         }
     }
 }

--- a/com.mirror.steamworks.net/NextServer.cs
+++ b/com.mirror.steamworks.net/NextServer.cs
@@ -1,14 +1,14 @@
 #if !DISABLESTEAMWORKS
-using Steamworks;
 using System;
 using System.Linq;
+using Steamworks;
 using UnityEngine;
 
 namespace Mirror.FizzySteam
 {
     public class NextServer : NextCommon, IServer
     {
-        private event Action<int,string> OnConnectedWithAddress;
+        private event Action<int, string> OnConnectedWithAddress;
         private event Action<int, byte[], int> OnReceivedData;
         private event Action<int> OnDisconnected;
         private event Action<int, TransportError, string> OnReceivedError;
@@ -40,7 +40,7 @@ namespace Mirror.FizzySteam
         {
             server = new NextServer(maxConnections);
 
-            server.OnConnectedWithAddress += (id,addres) => transport.OnServerConnectedWithAddress.Invoke(id,addres);
+            server.OnConnectedWithAddress += (id, addres) => transport.OnServerConnectedWithAddress.Invoke(id, addres);
             server.OnDisconnected += (id) => transport.OnServerDisconnected.Invoke(id);
             server.OnReceivedData += (id, data, ch) => transport.OnServerDataReceived.Invoke(id, new ArraySegment<byte>(data), ch);
             server.OnReceivedError += (id, error, reason) => transport.OnServerError.Invoke(id, error, reason);
@@ -109,7 +109,7 @@ namespace Mirror.FizzySteam
                 int connectionId = nextConnectionID++;
                 connToMirrorID.Add(param.m_hConn, connectionId);
                 steamIDToMirrorID.Add(param.m_info.m_identityRemote.GetSteamID(), connectionId);
-                OnConnectedWithAddress?.Invoke(connectionId,server.ServerGetClientAddress(connectionId));
+                OnConnectedWithAddress?.Invoke(connectionId, server.ServerGetClientAddress(connectionId));
                 Debug.Log($"Client with SteamID {clientSteamID} connected. Assigning connection id {connectionId}");
             }
             else if (param.m_info.m_eState == ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ClosedByPeer || param.m_info.m_eState == ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ProblemDetectedLocally)
@@ -195,11 +195,11 @@ namespace Mirror.FizzySteam
             }
         }
 
-        public void Send(int connectionId, byte[] data, int channelId)
+        public void Send(int connectionId, ArraySegment<byte> segment, int channelId)
         {
             if (connToMirrorID.TryGetValue(connectionId, out HSteamNetConnection conn))
             {
-                EResult res = SendSocket(conn, data, channelId);
+                EResult res = SendSocket(conn, segment, channelId);
 
                 if (res == EResult.k_EResultNoConnection || res == EResult.k_EResultInvalidParam)
                 {


### PR DESCRIPTION
Use ArraySegment<byte> and buffers allocated at startup to avoid runtime memory allocations.

To any reviewers:
1. Is zeroing the messagePtr arrays in NextClient.cs and NextServer.cs necessary?
2. Is the commented out code inside of ProcessMessage() in NextCommon.cs a good way of handling oversize packets or should it stay the way it is?

Thanks!