### PR TITLE
Change property types for FirstTypes and SecondTypes

### DIFF
--- a/com.mirror.steamworks.net/BidirectionalDictionary.cs
+++ b/com.mirror.steamworks.net/BidirectionalDictionary.cs
@@ -8,8 +8,8 @@ namespace Mirror.FizzySteam
         private Dictionary<T1, T2> t1ToT2Dict = new Dictionary<T1, T2>();
         private Dictionary<T2, T1> t2ToT1Dict = new Dictionary<T2, T1>();
 
-        public IEnumerable<T1> FirstTypes => t1ToT2Dict.Keys;
-        public IEnumerable<T2> SecondTypes => t2ToT1Dict.Keys;
+        public Dictionary<T1, T2>.KeyCollection FirstTypes => t1ToT2Dict.Keys;
+        public Dictionary<T2, T1>.KeyCollection SecondTypes => t2ToT1Dict.Keys;
 
         public IEnumerator GetEnumerator() => t1ToT2Dict.GetEnumerator();
 


### PR DESCRIPTION
IEnumerable allocates 40b/frame, replacing with KeyCollection removes this gc allocation.