### PR TITLE
Optimize connection iteration in FlushData and ReceiveData

### DIFF
--- a/com.mirror.steamworks.net/NextServer.cs
+++ b/com.mirror.steamworks.net/NextServer.cs
@@ -162,7 +162,7 @@ namespace Mirror.FizzySteam
 
         public void FlushData()
         {
-            foreach (HSteamNetConnection conn in connToMirrorID.FirstTypes.ToList())
+            foreach (HSteamNetConnection conn in connToMirrorID.FirstTypes)
             {
 #if UNITY_SERVER
                 SteamGameServerNetworkingSockets.FlushMessagesOnConnection(conn);
@@ -174,7 +174,7 @@ namespace Mirror.FizzySteam
 
         public void ReceiveData()
         {
-            foreach (HSteamNetConnection conn in connToMirrorID.FirstTypes.ToList())
+            foreach (HSteamNetConnection conn in connToMirrorID.FirstTypes)
             {
                 if (connToMirrorID.TryGetValue(conn, out int connId))
                 {


### PR DESCRIPTION
Removed unnecessary ToList() calls in FlushData and ReceiveData methods to avoid GC-allocation/Linq in hotloops.